### PR TITLE
[Follow/Porring-64] 팔로우 이름 수정 & 팔로우 취소 다이얼로그

### DIFF
--- a/core/common/src/main/kotlin/com/kolown/porring/core/common/component/DetailItem.kt
+++ b/core/common/src/main/kotlin/com/kolown/porring/core/common/component/DetailItem.kt
@@ -247,12 +247,7 @@ private fun ReelsContent(
                                 DetailButton(
                                     onClick = {
                                         if (isLoggedIn) {
-                                            if (isFollowed.value) {
-                                                onUnfollowClick(imageItem.authorId)
-                                                updateFollow(imageItem.authorId)
-                                            } else {
-                                                isFollowDialogVisible.value = true
-                                            }
+                                            isFollowDialogVisible.value = true
                                         } else {
                                             snackBarBridge.postSnackBarEvent(SnackBarEvent.LoginRequired())
                                         }
@@ -286,13 +281,30 @@ private fun ReelsContent(
         }
     }
 
-    if (isFollowDialogVisible.value)
-        FollowDialog(onClickCancel = {
-            isFollowDialogVisible.value = false
-        }, onClickConfirm = { name ->
-            onFollowClick(imageItem.authorId, name)
-            updateFollow(imageItem.authorId)
-        })
+    if (isFollowDialogVisible.value) {
+        if (isFollowed.value) {
+            // TODO Exchange to AlertDialog
+            UnfollowCheckDialog(
+                title = stringResource(R.string.string_unfollow),
+                description = stringResource(R.string.string_unfollow_description),
+                dismissText = stringResource(R.string.string_cancel),
+                confirmText = stringResource(R.string.string_confirm),
+                onDismissRequest = { isFollowDialogVisible.value = false },
+                onConfirm = {
+                    onUnfollowClick(imageItem.authorId)
+                    updateFollow(imageItem.authorId)
+                }
+            )
+        } else {
+            FollowDialog(
+                onClickCancel = { isFollowDialogVisible.value = false },
+                onClickConfirm = { name ->
+                    onFollowClick(imageItem.authorId, name)
+                    updateFollow(imageItem.authorId)
+                }
+            )
+        }
+    }
 }
 
 

--- a/core/common/src/main/kotlin/com/kolown/porring/core/common/component/FollowDialog.kt
+++ b/core/common/src/main/kotlin/com/kolown/porring/core/common/component/FollowDialog.kt
@@ -45,11 +45,23 @@ import com.kolown.porring.core.designsystem.ui.theme.Surface2
 @Composable
 fun FollowDialog(
     modifier: Modifier = Modifier,
+    isAddFollow: Boolean = true,
     onClickCancel: () -> Unit = {},
     onClickConfirm: (String) -> Unit = {}
 ) {
     val textValue = remember { mutableStateOf("") }
     val isFollowerNameEmpty = remember { mutableStateOf(false) }
+    val followTitle = if (isAddFollow) {
+        stringResource(R.string.string_follow_title)
+    } else {
+        stringResource(R.string.string_edit_name)
+    }
+    val confirmText = if (isAddFollow) {
+        stringResource(R.string.string_confirm_follow)
+    } else {
+        stringResource(R.string.string_confirm_edit)
+    }
+
     Dialog(
         onDismissRequest = { onClickCancel() },
         properties = DialogProperties(
@@ -73,9 +85,9 @@ fun FollowDialog(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
             ) {
-                Text(text = "팔로우 추가하기", style = MaterialTheme.typography.headlineSmall)
+                Text(text = followTitle, style = MaterialTheme.typography.headlineSmall)
                 Spacer(modifier = Modifier.height(15.dp))
-                Text(text = "원하는 이름을 입력해 주세요.", style = MaterialTheme.typography.bodyMedium)
+                Text(text = stringResource(R.string.string_insert_name), style = MaterialTheme.typography.bodyMedium)
                 Spacer(modifier = Modifier.height(15.dp))
                 OutlinedTextField(
                     value = textValue.value,
@@ -106,12 +118,14 @@ fun FollowDialog(
                 )
                 Spacer(modifier = Modifier.height(5.dp))
                 Box(modifier = Modifier.fillMaxWidth()) {
-                    if (isFollowerNameEmpty.value) Text(
-                        text = "이름을 입력해주세요.",
-                        fontSize = 10.sp,
-                        modifier = Modifier.align(Alignment.CenterStart),
-                        color = Error
-                    )
+                    if (isFollowerNameEmpty.value) {
+                        Text(
+                            text = stringResource(R.string.string_insert_name_error),
+                            fontSize = 10.sp,
+                            modifier = Modifier.align(Alignment.CenterStart),
+                            color = Error
+                        )
+                    }
                     Text(
                         text = "(${textValue.value.length}/10)",
                         modifier = Modifier.align(Alignment.CenterEnd),
@@ -135,7 +149,7 @@ fun FollowDialog(
                         },
                         colors = ButtonDefaults.buttonColors(containerColor = Color.White)
                     ) {
-                        Text(text = stringResource(R.string.string_add_follow), color = Primary)
+                        Text(text = confirmText, color = Primary)
                     }
                 }
             }

--- a/core/common/src/main/kotlin/com/kolown/porring/core/common/component/UnfollowCheckDialog.kt
+++ b/core/common/src/main/kotlin/com/kolown/porring/core/common/component/UnfollowCheckDialog.kt
@@ -1,4 +1,4 @@
-package com.kolown.porring.feature.home.component
+package com.kolown.porring.core.common.component
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
@@ -34,7 +34,7 @@ import com.kolown.porring.core.designsystem.ui.theme.Error
 import com.kolown.porring.core.designsystem.ui.theme.Primary
 
 @Composable
-internal fun PorringAlertDialog(
+fun UnfollowCheckDialog(
     title: String = "",
     description: String = "",
     @DrawableRes iconResId: Int? = null,
@@ -132,7 +132,7 @@ private fun PreviewPermissionEduDialog() {
                 .padding(innerPadding),
             contentAlignment = Alignment.Center
         ) {
-            PorringAlertDialog()
+            UnfollowCheckDialog()
         }
     }
 }

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -13,10 +13,15 @@
     <string name="string_follow">팔로우</string>
     <string name="string_gallery">갤러리</string>
     <string name="string_follow_cancel">취소하기</string>
-    <string name="string_add_follow">팔로우 추가</string>
-
+    <string name="string_insert_name">원하는 이름을 입력해 주세요.</string>
+    <string name="string_follow_title">팔로우 추가하기</string>
+    <string name="string_insert_name_error">이름을 입력해주세요.</string>
+    <string name="string_confirm_follow">팔로우 추가</string>
+    <string name="string_edit_name">이름 수정하기</string>
+    <string name="string_confirm_edit">이름 수정</string>
 
     <!--not available version screen-->
     <string name="description_not_available_version">사용 불가능한 이전 버전입니다.\n업데이트를 진행해주세요.</string>
     <string name="button_exit_app"> 앱 종료</string>
+
 </resources>

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="string_question_delete">이 게시물을 삭제하시겠어요?</string>
     <string name="string_cancel">취소</string>
     <string name="string_remove">삭제</string>
+    <string name="string_confirm">확인</string>
     <string name="string_can_not_load">이미지를 로드할 수 없습니다.</string>
     <string name="string_retry">Retry</string>
     <string name="string_follow">팔로우</string>
@@ -19,9 +20,12 @@
     <string name="string_confirm_follow">팔로우 추가</string>
     <string name="string_edit_name">이름 수정하기</string>
     <string name="string_confirm_edit">이름 수정</string>
+    <string name="string_unfollow">팔로우 취소</string>
+    <string name="string_unfollow_description">팔로우를 취소하시겠습니까?</string>
 
     <!--not available version screen-->
     <string name="description_not_available_version">사용 불가능한 이전 버전입니다.\n업데이트를 진행해주세요.</string>
     <string name="button_exit_app"> 앱 종료</string>
+
 
 </resources>

--- a/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerContent.kt
+++ b/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerContent.kt
@@ -1,0 +1,107 @@
+package com.kolown.porring.feature.follower
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.kolown.porring.core.common.component.CoilImage
+import com.kolown.porring.core.designsystem.ui.theme.Error
+import com.kolown.porring.core.designsystem.ui.theme.Primary
+
+@Composable
+internal fun FollowContent(
+    followerName: String = "name",
+    followAlbums: List<String> = listOf(),
+    navigateToTheir: () -> Unit = {},
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null
+            ) {
+                navigateToTheir()
+            }
+            .padding(16.dp),
+        verticalArrangement = Arrangement.Center
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = followerName,
+                color = Primary,
+                style = MaterialTheme.typography.titleLarge
+            )
+            TextButton (
+                onClick = { /*TODO*/ }
+            ) {
+                Text(
+                    text = stringResource(R.string.string_edit),
+                    color = Error,
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(10.dp))
+        LazyRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.CenterHorizontally),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(
+                space = 8.dp
+            )
+        ) {
+            items(followAlbums) { imageUrl ->
+                Card(
+                    modifier = Modifier
+                        .size(100.dp)
+                        .clip(RoundedCornerShape(10.dp)),
+                ) {
+                    CoilImage(
+                        imageUrl = imageUrl,
+                        onClickEnabled = false
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewFollowContent() {
+    FollowContent()
+}

--- a/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerContent.kt
+++ b/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerContent.kt
@@ -1,6 +1,5 @@
 package com.kolown.porring.feature.follower
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
@@ -15,21 +14,23 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kolown.porring.core.common.component.CoilImage
+import com.kolown.porring.core.common.component.FollowDialog
 import com.kolown.porring.core.designsystem.ui.theme.Error
 import com.kolown.porring.core.designsystem.ui.theme.Primary
 
@@ -38,8 +39,11 @@ internal fun FollowContent(
     followerName: String = "name",
     followAlbums: List<String> = listOf(),
     navigateToTheir: () -> Unit = {},
+    // TODO: If need id, add Int
+    editFollowName: (String) -> Unit = { _ -> },
 ) {
     val interactionSource = remember { MutableInteractionSource() }
+    var isFollowDialogVisible by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier
@@ -65,7 +69,9 @@ internal fun FollowContent(
                 style = MaterialTheme.typography.titleLarge
             )
             TextButton (
-                onClick = { /*TODO*/ }
+                onClick = {
+                    isFollowDialogVisible = true
+                }
             ) {
                 Text(
                     text = stringResource(R.string.string_edit),
@@ -96,6 +102,13 @@ internal fun FollowContent(
                     )
                 }
             }
+        }
+        if (isFollowDialogVisible) {
+            FollowDialog(
+                isAddFollow = false,
+                onClickCancel = { isFollowDialogVisible = false },
+                onClickConfirm = { name -> editFollowName(name) }
+            )
         }
     }
 }

--- a/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerScreen.kt
+++ b/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerScreen.kt
@@ -141,7 +141,9 @@ internal fun FollowerRoute(
                                 pagerState = pagerState,
                                 navigateToTheir = navigateToTheir
                             )
-                        } else NoFollowerScreen()
+                        } else {
+                            NoFollowerScreen()
+                        }
                     }
                 }
 
@@ -179,9 +181,7 @@ private fun FollowerScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.White),
-        contentPadding = PaddingValues(horizontal = 16.dp),
         state = pagerState,
-        verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
         items(items.itemCount) { index ->
             items[index]?.let {
@@ -196,67 +196,6 @@ private fun FollowerScreen(
             item(key = "") {
                 PageItemFooter(loadState = items.loadState.append) {
                     items.retry()
-                }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-internal fun FollowContent(
-    followerName: String,
-    followAlbums: List<String>,
-    navigateToTheir: () -> Unit,
-) {
-    val interactionSource = remember { MutableInteractionSource() }
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .wrapContentHeight()
-            .clickable {
-                navigateToTheir()
-            },
-        verticalArrangement = Arrangement.Center
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = followerName,
-                color = Primary,
-                style = MaterialTheme.typography.titleLarge
-            )
-        }
-        Spacer(modifier = Modifier.height(10.dp))
-        LazyRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .align(Alignment.CenterHorizontally),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(
-                space = 8.dp
-            )
-        ) {
-            items(followAlbums) { imageUrl ->
-                Card(
-                    modifier = Modifier
-                        .size(100.dp)
-                        .clip(RoundedCornerShape(10.dp))
-                        .combinedClickable(
-                            indication = null,
-                            interactionSource = interactionSource,
-                            onClick = {
-                                navigateToTheir()
-                            }
-                        ),
-                    colors = CardDefaults.cardColors(containerColor = Color.LightGray)
-                ) {
-                    CoilImage(
-                        imageUrl = imageUrl,
-                        onClickEnabled = false
-                    )
-
                 }
             }
         }

--- a/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerScreen.kt
+++ b/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerScreen.kt
@@ -188,7 +188,10 @@ private fun FollowerScreen(
                 FollowContent(
                     followerName = it.followerName,
                     followAlbums = it.posts,
-                    navigateToTheir = { navigateToTheir(it.id) }
+                    navigateToTheir = { navigateToTheir(it.id) },
+                    editFollowName = { name ->
+                        // TODO: Follow Name Edit Api connect
+                    }
                 )
             }
         }

--- a/feature/follower/src/main/res/values/strings.xml
+++ b/feature/follower/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="string_not_follow">팔로잉 하고 있는 사람이 없습니다.</string>
     <string name="string_error">오류가 발생하였습니다!</string>
     <string name="string_retry">Retry</string>
+    <string name="string_edit">수정</string>
 </resources>

--- a/feature/home/src/main/java/com/kolown/porring/feature/home/component/RandomImageList.kt
+++ b/feature/home/src/main/java/com/kolown/porring/feature/home/component/RandomImageList.kt
@@ -161,11 +161,7 @@ private fun ImageCard(
                 navigateToTheir = { navigateToTheir(imageItem.authorId) },
                 onFollowClick = {
                     if (isLoggedIn) {
-                        if (imageItem.isFollower) {
-                            onUnfollowClick(imageItem.authorId)
-                        } else {
-                            isFollowDialogVisible = true
-                        }
+                        isFollowDialogVisible = true
                     } else {
                         snackBarBridge.postSnackBarEvent(SnackBarEvent.LoginRequired())
                     }
@@ -202,12 +198,23 @@ private fun ImageCard(
             )
         }
         if (isFollowDialogVisible) {
-            FollowDialog(
-                onClickCancel = { isFollowDialogVisible = false },
-                onClickConfirm = { name ->
-                    onFollowClick(imageItem.authorId, name)
-                }
-            )
+            if(imageItem.isFollower) {
+                PorringAlertDialog(
+                    title = "팔로우 취소",
+                    description = "팔로우를 취소하시겠습니까?",
+                    dismissText = "취소",
+                    confirmText = "확인",
+                    onDismissRequest = { isFollowDialogVisible = false },
+                    onConfirm = { onUnfollowClick(imageItem.authorId) }
+                )
+            } else {
+                FollowDialog(
+                    onClickCancel = { isFollowDialogVisible = false },
+                    onClickConfirm = { name ->
+                        onFollowClick(imageItem.authorId, name)
+                    }
+                )
+            }
         }
     }
 }

--- a/feature/home/src/main/java/com/kolown/porring/feature/home/component/RandomImageList.kt
+++ b/feature/home/src/main/java/com/kolown/porring/feature/home/component/RandomImageList.kt
@@ -35,15 +35,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kolown.porring.core.common.component.CoilImage
 import com.kolown.porring.core.common.component.FollowDialog
 import com.kolown.porring.core.common.component.LocalSnackBarBridge
+import com.kolown.porring.core.common.component.UnfollowCheckDialog
 import com.kolown.porring.core.designsystem.ui.theme.Primary
 import com.kolown.porring.core.model.PostContentModel
 import com.kolown.porring.core.model.Reactions
 import com.kolown.porring.core.model.SnackBarEvent
+import com.kolown.porring.feature.home.R
 
 @Composable
 internal fun RandomImageList(
@@ -103,15 +106,14 @@ private fun ImageCard(
 ) {
     val likedImageVector =
         if (imageItem.myReaction == null) Icons.Outlined.FavoriteBorder else Icons.Outlined.Favorite
-    var isFollowDialogVisible by remember { mutableStateOf(false) }
-    var isFirstRenderer by remember { mutableStateOf(true) }
+    val isFollowDialogVisible = remember { mutableStateOf(false) }
+    val isFirstRenderer = remember { mutableStateOf(true) }
     val sizeAnimation = remember { Animatable(1f) }
 
     val snackBarBridge = LocalSnackBarBridge.current
 
-
     LaunchedEffect(imageItem.myReaction) {
-        if (!isFirstRenderer) {
+        if (!isFirstRenderer.value) {
             sizeAnimation.animateTo(
                 targetValue = 1.4f,
                 animationSpec = tween(durationMillis = 100)
@@ -129,7 +131,7 @@ private fun ImageCard(
                 animationSpec = tween(durationMillis = 100)
             )
         } else {
-            isFirstRenderer = false
+            isFirstRenderer.value = false
         }
     }
 
@@ -161,7 +163,7 @@ private fun ImageCard(
                 navigateToTheir = { navigateToTheir(imageItem.authorId) },
                 onFollowClick = {
                     if (isLoggedIn) {
-                        isFollowDialogVisible = true
+                        isFollowDialogVisible.value = true
                     } else {
                         snackBarBridge.postSnackBarEvent(SnackBarEvent.LoginRequired())
                     }
@@ -197,19 +199,20 @@ private fun ImageCard(
                 tint = Primary
             )
         }
-        if (isFollowDialogVisible) {
+        if (isFollowDialogVisible.value) {
             if(imageItem.isFollower) {
-                PorringAlertDialog(
-                    title = "팔로우 취소",
-                    description = "팔로우를 취소하시겠습니까?",
-                    dismissText = "취소",
-                    confirmText = "확인",
-                    onDismissRequest = { isFollowDialogVisible = false },
+                // TODO Exchange to AlertDialog
+                UnfollowCheckDialog(
+                    title = stringResource(R.string.string_unfollow),
+                    description = stringResource(R.string.string_unfollow_description),
+                    dismissText = stringResource(R.string.string_cancel),
+                    confirmText = stringResource(R.string.string_confirm),
+                    onDismissRequest = { isFollowDialogVisible.value = false },
                     onConfirm = { onUnfollowClick(imageItem.authorId) }
                 )
             } else {
                 FollowDialog(
-                    onClickCancel = { isFollowDialogVisible = false },
+                    onClickCancel = { isFollowDialogVisible.value = false },
                     onClickConfirm = { name ->
                         onFollowClick(imageItem.authorId, name)
                     }

--- a/feature/home/src/main/java/com/kolown/porring/feature/home/component/UnfollowCheckDialog.kt
+++ b/feature/home/src/main/java/com/kolown/porring/feature/home/component/UnfollowCheckDialog.kt
@@ -1,0 +1,138 @@
+package com.kolown.porring.feature.home.component
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.kolown.porring.core.designsystem.ui.theme.Error
+import com.kolown.porring.core.designsystem.ui.theme.Primary
+
+@Composable
+internal fun PorringAlertDialog(
+    title: String = "",
+    description: String = "",
+    @DrawableRes iconResId: Int? = null,
+    dismissText: String = "",
+    confirmText: String = "",
+    onDismissRequest: () -> Unit = {},
+    onConfirm: () -> Unit = {},
+) {
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            dismissOnBackPress = true,
+            dismissOnClickOutside = true,
+        )
+    ) {
+        Card(
+            shape = RoundedCornerShape(8.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth(0.92f)
+                    .background(color = Color.White)
+                    .padding(vertical = 24.dp, horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically)
+            ) {
+                iconResId?.let {
+                    Icon(
+                        imageVector = ImageVector.vectorResource(iconResId),
+                        contentDescription = null,
+                        tint = Primary,
+                        modifier = Modifier.size(24.dp)
+                    )
+                }
+
+                Text(
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold,
+                    text = title,
+                    color = Primary
+                )
+
+                Text(
+                    style = MaterialTheme.typography.bodySmall,
+                    textAlign = TextAlign.Start,
+                    text = description
+                )
+
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(24.dp, Alignment.End)
+                ) {
+                    TextButton(
+                        onClick = {
+                            onDismissRequest()
+                        }
+                    ) {
+                        Text(
+                            style = MaterialTheme.typography.labelLarge,
+                            color = Error,
+                            text = dismissText
+                        )
+                    }
+
+                    TextButton(
+                        onClick = {
+                            onDismissRequest()
+                            onConfirm()
+                        }
+                    ) {
+                        Text(
+                            style = MaterialTheme.typography.labelLarge,
+                            fontWeight = FontWeight.Bold,
+                            color = Primary,
+                            text = confirmText
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(
+    showBackground = true,
+    device = Devices.PIXEL_5
+)
+@Composable
+private fun PreviewPermissionEduDialog() {
+    Scaffold { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding),
+            contentAlignment = Alignment.Center
+        ) {
+            PorringAlertDialog()
+        }
+    }
+}

--- a/feature/home/src/main/res/values/strings.xml
+++ b/feature/home/src/main/res/values/strings.xml
@@ -4,4 +4,8 @@
     <string name="string_error">오류가 발생하였습니다!</string>
     <string name="string_can_not_load">이미지를 로드할 수 없음. 다시 시도해주세요.</string>
     <string name="string_reaction_icon">reaction icon</string>
+    <string name="string_unfollow">팔로우 취소</string>
+    <string name="string_unfollow_description">팔로우를 취소하시겠습니까?</string>
+    <string name="string_cancel">취소</string>
+    <string name="string_confirm">확인</string>
 </resources>

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/MainActivity.kt
@@ -63,6 +63,8 @@ class MainActivity : ComponentActivity() {
 
             }
         }
-        window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        if(!BuildConfig.DEBUG) {
+            window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+        }
     }
 }

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainBottomBar.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainBottomBar.kt
@@ -98,11 +98,11 @@ internal fun MainBottomBar(
 
             if (showRationale) {
                 PorringAlertDialog(
-                    title = stringResource(R.string.camera_permission_guide),
-                    description = stringResource(R.string.camera_rationale_script),
+                    title = stringResource(R.string.string_camera_permission_guide),
+                    description = stringResource(R.string.string_camera_rationale_script),
                     iconResId = R.drawable.ic_camera_24dp,
-                    dismissText = stringResource(R.string.close),
-                    confirmText = stringResource(R.string.confirm),
+                    dismissText = stringResource(R.string.string_close),
+                    confirmText = stringResource(R.string.string_confirm),
                     onDismissRequest = { showRationale = false },
                     onConfirm = { cameraPermissionLauncher.launch(Manifest.permission.CAMERA) },
                 )
@@ -112,11 +112,11 @@ internal fun MainBottomBar(
                 val context = LocalContext.current
 
                 PorringAlertDialog(
-                    title = stringResource(R.string.camera_permission_guide),
-                    description = stringResource(R.string.camera_permission_guide_script),
+                    title = stringResource(R.string.string_camera_permission_guide),
+                    description = stringResource(R.string.string_camera_permission_guide_script),
                     iconResId = R.drawable.ic_camera_24dp,
-                    dismissText = stringResource(R.string.close),
-                    confirmText = stringResource(R.string.go_to_setting),
+                    dismissText = stringResource(R.string.string_close),
+                    confirmText = stringResource(R.string.string_go_to_setting),
                     onDismissRequest = { showSetting = false },
                     onConfirm = {
                         val intent =

--- a/feature/main/src/main/res/values/strings.xml
+++ b/feature/main/src/main/res/values/strings.xml
@@ -6,10 +6,10 @@
     <string name="string_move">이동</string>
     <string name="string_uploading">업로드 중입니다.</string>
     <string name="string_upload_success">업로드 성공! MyGallery로 이동하시려면 이동을 눌러주세요!</string>
-    <string name="camera_permission_guide">카메라 권한 허용 안내</string>
-    <string name="camera_rationale_script">카메라 기능을 사용하기 위해서는 카메라 권한이 허용되어야 합니다. 카메라 기능을 사용하시려면 카메라 권한을 허용해 주세요.</string>
-    <string name="close">닫기</string>
-    <string name="go_to_setting">설정으로 이동</string>
-    <string name="camera_permission_guide_script"><![CDATA[카메라 기능을 사용하기 위해서는 카메라 권한 허용이 필요합니다. 설정화면에서 카메라 권한을 허용해 주세요.\n※ 애플리케이션 정보 > 권한 > 카메라 > 앱 사용 중에만 허용]]></string>
-    <string name="confirm">확인</string>
+    <string name="string_camera_permission_guide">카메라 권한 허용 안내</string>
+    <string name="string_camera_rationale_script">카메라 기능을 사용하기 위해서는 카메라 권한이 허용되어야 합니다. 카메라 기능을 사용하시려면 카메라 권한을 허용해 주세요.</string>
+    <string name="string_close">닫기</string>
+    <string name="string_go_to_setting">설정으로 이동</string>
+    <string name="string_camera_permission_guide_script"><![CDATA[카메라 기능을 사용하기 위해서는 카메라 권한 허용이 필요합니다. 설정화면에서 카메라 권한을 허용해 주세요.\n※ 애플리케이션 정보 > 권한 > 카메라 > 앱 사용 중에만 허용]]></string>
+    <string name="string_confirm">확인</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관 이슈
#Porring-64

## 📝작업 내용
- 팔로우 화면에서 이름 수정 가능하도록 구현
- 팔로우 취소할 때 다이얼로그 띄우기

### 작업 상세 
- 팔로우 추가 다이얼로그를 활용하여 이름 수정 가능하도록 구현
- Home, Detail에서 팔로우 취소 다이얼로그 띄우기 구현

### 스크린샷 

![KakaoTalk_20250205_222536175](https://github.com/user-attachments/assets/5c11251e-c969-407b-8e69-578cdaca80e0)
![KakaoTalk_20250205_222536175_01](https://github.com/user-attachments/assets/c7039208-b23c-4b9e-8c4d-db315a048e40)

## ✅ TODO
1. Follow Name Edit api 연결 작업은 API가 제공되면 연결하는 것으로 연기
2. PorringAlertDialog가 designsystem으로 오면 해당 컴포넌트 사용하는 것으로 변경 예정
