### PR TITLE
firestore 데이터 구조 변경 및 홈 화면 데이터 fetch로직 수정

### DIFF
--- a/core/data/src/main/java/com/kolown/porring/core/data/repository/PostRepository.kt
+++ b/core/data/src/main/java/com/kolown/porring/core/data/repository/PostRepository.kt
@@ -256,39 +256,17 @@ class PostRepositoryImpl @Inject constructor(
             Log.e("fatal: postRepository", it.toString())
             throw IOException("게시물 불러오기 실패")
         }
-        val (tags, reactions, isFollowers) = coroutineScope {
-            val tagsDeferred = async {
-                posts.map {
-                    async {
-                        tagDataSource.getPostTag(it.postId).getOrElse {
-                            throw IOException("태그 불러오기 실패")
-                        }
+        val isFollowers = coroutineScope {
+            posts.map {
+                async {
+                    followDataSource.getIsFollower(
+                        userId = currentUserId,
+                        followerId = it.authorId
+                    ).getOrElse {
+                        throw IOException("팔로우 확인 실패")
                     }
-                }.awaitAll()
-            }
-            val reactionsDeferred = async {
-                posts.map {
-                    async {
-                        reactionDataSource.getReactionByPostId(it.postId).getOrElse {
-                            throw IOException("리액션 불러오기 실패")
-                        }
-                    }
-                }.awaitAll()
-            }
-            val followDeferred = async {
-                posts.map {
-                    async {
-                        followDataSource.getIsFollower(
-                            userId = currentUserId,
-                            followerId = it.authorId
-                        ).getOrElse {
-                            throw IOException("팔로우 확인 실패")
-                        }
-                    }
-                }.awaitAll()
-            }
-
-            Triple(tagsDeferred.await(), reactionsDeferred.await(), followDeferred.await())
+                }
+            }.awaitAll()
         }
 
         val postContentModels = posts.mapIndexed { index, postModel ->
@@ -298,10 +276,10 @@ class PostRepositoryImpl @Inject constructor(
                 imageUrl = postModel.imageUrl,
                 registerAt = postModel.registerAt,
                 description = postModel.description,
-                tags = tags[index].map { it.tagName },
+                tags = postModel.tags,
                 isFollower = isFollowers[index],
-                reactions = reactions[index].mapNotNull { it.reaction },
-                myReaction = reactions[index].find { it.userId == currentUserId }?.reaction
+                reactions = postModel.reactions,
+                myReaction = postModel.myReaction
             )
         }
 

--- a/core/model/src/main/java/com/kolown/porring/core/model/PostModel.kt
+++ b/core/model/src/main/java/com/kolown/porring/core/model/PostModel.kt
@@ -6,5 +6,8 @@ data class PostModel(
     val imageUrl: String,
     val registerAt: String,
     val description: String,
+    val tags: List<String>,
+    val reactions: List<Reactions>,
+    val myReaction: Reactions?,
     val random: Long = 0L
 )

--- a/core/network/src/main/java/com/kolown/porring/core/network/PostDataSource.kt
+++ b/core/network/src/main/java/com/kolown/porring/core/network/PostDataSource.kt
@@ -6,6 +6,9 @@ import com.google.firebase.firestore.Query
 import com.kolown.porring.core.model.PostModel
 import com.kolown.porring.core.network.model.PostDto
 import com.kolown.porring.core.network.model.toPostModel
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
@@ -113,38 +116,63 @@ class PostDataSourceImpl @Inject constructor(
             val randomValue = (0..Long.MAX_VALUE).random()
             val queryDirection =
                 listOf(Query.Direction.ASCENDING, Query.Direction.DESCENDING).random()
+
             val query = postCollection
                 .whereNotEqualTo("authorId", uid)
                 .whereGreaterThan("random${this.randomType}", randomValue)
                 .orderBy("random${this.randomType}", queryDirection)
                 .limit(count.toLong())
-            val result = query
-                .get()
-                .await()
-                .map { querySnapshot ->
-                    querySnapshot
-                        .toObject(PostDto::class.java)
-                        .toPostModel(this.randomType)
-                }
 
-            if (result.size < count) {
-                val remainingCount = count - result.size
-                val fallbackQuery = postCollection
-                    .whereNotEqualTo("authorId", uid)
-                    .whereGreaterThan("random${this.randomType}", 0)
-                    .orderBy("random${this.randomType}", queryDirection)
-                    .limit(remainingCount.toLong())
-                    .get()
-                    .await()
-                    .map { querySnapshot ->
-                        querySnapshot
-                            .toObject(PostDto::class.java)
-                            .toPostModel(this.randomType)
+            val initialPosts = query.get().await()
+            val resultPosts = if (initialPosts.size() < count) {
+                val remainingCount = count - initialPosts.size()
+                val fallbackQuery = when (queryDirection) {
+                    Query.Direction.ASCENDING -> {
+                        postCollection
+                            .whereNotEqualTo("authorId", uid)
+                            .whereGreaterThan("random${this.randomType}", 0)
+                            .orderBy("random${this.randomType}", queryDirection)
+                            .limit(remainingCount.toLong())
                     }
 
-                result + fallbackQuery
+                    Query.Direction.DESCENDING -> {
+                        postCollection
+                            .whereNotEqualTo("authorId", uid)
+                            .whereLessThan("random${this.randomType}", Long.MAX_VALUE)
+                            .orderBy("random${this.randomType}", queryDirection)
+                            .limit(remainingCount.toLong())
+                    }
+                }.get().await()
+
+                initialPosts + fallbackQuery
             } else {
-                result
+                initialPosts
+            }
+
+            coroutineScope {
+                resultPosts.map { querySnapshot ->
+                    async {
+                        val reactionQuery = postCollection
+                            .document(querySnapshot.id)
+                            .collection("reactions")
+                            .get()
+                            .await()
+                        val reactions = reactionQuery
+                            .mapNotNull { it.getLong("reaction")?.toInt() }
+                            .distinct()
+                        val myReaction = reactionQuery
+                            .find { it.id == uid }
+                            ?.getLong("reaction")
+                            ?.toInt()
+
+                        querySnapshot.toObject(PostDto::class.java)
+                            .copy(
+                                reactions = reactions,
+                                myReaction = myReaction
+                            )
+                            .toPostModel(randomType)
+                    }
+                }.awaitAll()
             }
         }
     }

--- a/core/network/src/main/java/com/kolown/porring/core/network/model/PostDto.kt
+++ b/core/network/src/main/java/com/kolown/porring/core/network/model/PostDto.kt
@@ -1,6 +1,8 @@
 package com.kolown.porring.core.network.model
 
 import com.kolown.porring.core.model.PostModel
+import com.kolown.porring.core.model.Reactions
+import com.kolown.porring.core.model.toReactions
 import com.kolown.porring.core.network.Util.randomValue
 
 data class PostDto(
@@ -9,6 +11,9 @@ data class PostDto(
     val imageUrl: String = "",
     val registerAt: String = "",
     val description: String = "",
+    val tags: List<String> = emptyList(),
+    val reactions: List<Int> = emptyList(),
+    val myReaction: Int? = null,
     val randomA: Long = randomValue(),
     val randomB: Long = randomValue(),
     val randomC: Long = randomValue(),
@@ -16,13 +21,18 @@ data class PostDto(
     val randomE: Long = randomValue(),
 )
 
-fun PostDto.toPostModel(seed: String = "A"): PostModel {
+fun PostDto.toPostModel(
+    seed: String = "A"
+): PostModel {
     return PostModel(
         postId = this.postId,
         authorId = this.authorId,
         imageUrl = this.imageUrl,
         registerAt = this.registerAt,
         description = this.description,
+        tags = this.tags,
+        reactions = this.reactions.map { it.toReactions() ?: Reactions.LOVE },
+        myReaction = this.myReaction?.toReactions(),
         random = when (seed) {
             "A" -> randomA
             "B" -> randomB


### PR DESCRIPTION
## 📝작업 내용
기존에 분산되어 있던 post의 데이터를 noSQL구조에 맞게 post에서 모두 관리하도록 변경.

### 작업 상세
- tag, reaction정보를 따로 불러오던 것을 하나의 post에서 불러오도록 변경.
- 로직 이전 완료 후 TagDataSource와 ReactionDataSource는 삭제해도 될듯함.
- 네트워크 요청 로직 변경으로 postDto와 postModel구조 변경

## ✅ TODO
- reaction의 경우 내부 컬렉션을 사용해 재요청이 이루어짐. 따라서 reaction에 대한 summary를 제공할 수 있도록 변경해서 한번에 요청을 가져오도록 변경해보면 좋을 것 같음.

