### PR TITLE
[Upload/Porring-100] 업로드 연동 및 리팩토링

### DIFF
--- a/core/common/src/main/kotlin/com/kolown/porring/core/common/Extension.kt
+++ b/core/common/src/main/kotlin/com/kolown/porring/core/common/Extension.kt
@@ -1,0 +1,8 @@
+package com.kolown.porring.core.common
+
+suspend fun <T> retry(times: Int, block: suspend () -> T): T {
+    repeat(times - 1) {
+        try { return block() } catch (e: Exception) { /* ignore */ }
+    }
+    return block()
+}

--- a/core/data/src/main/java/com/kolown/porring/core/data/di/DataSourceModule.kt
+++ b/core/data/src/main/java/com/kolown/porring/core/data/di/DataSourceModule.kt
@@ -32,7 +32,6 @@ abstract class DataSourceModule {
         postDataSource: PostDataSourceImpl,
     ): PostDataSource
 
-
     @Binds
     abstract fun bindTagDataSource(
         tagDataSource: TagDataSourceImpl,
@@ -48,7 +47,6 @@ abstract class DataSourceModule {
     abstract fun bindsAuthDatsSource(
         authDataSource: AuthDataSourceImpl,
     ): AuthDataSource
-
 
     @Binds
     abstract fun bindUploadDataSource(

--- a/core/data/src/main/java/com/kolown/porring/core/data/di/RepositoryModule.kt
+++ b/core/data/src/main/java/com/kolown/porring/core/data/di/RepositoryModule.kt
@@ -45,6 +45,7 @@ class ProvideRepositoryModule{
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
     @Binds
+    @Singleton
     abstract fun providePostRepository(
         postRepository: PostRepositoryImpl,
     ): PostRepository

--- a/core/data/src/main/java/com/kolown/porring/core/data/repository/ImageGenerateRepository.kt
+++ b/core/data/src/main/java/com/kolown/porring/core/data/repository/ImageGenerateRepository.kt
@@ -3,22 +3,16 @@ package com.kolown.porring.core.data.repository
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.graphics.ImageDecoder
 import android.graphics.Matrix
 import android.net.Uri
-import android.util.Log
-import android.util.Size
 import androidx.exifinterface.media.ExifInterface
 import com.kolown.porring.core.data.utils.Constants.IMAGE_LONG
-import com.kolown.porring.core.data.utils.Constants.IMAGE_RATIO
 import com.kolown.porring.core.data.utils.Constants.IMAGE_SHORT
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.FileOutputStream
-import java.io.IOException
-import kotlin.math.min
 
 interface ImageGenerateRepository {
     suspend fun saveBitmapToCache(
@@ -84,7 +78,7 @@ class ImageGenerateRepositoryImpl(
         val originalBitmap = decodeSampledBitmapFromUri(
             uri = Uri.parse(imageUri),
             resizeNeeded = false,
-            rotateNeeded = true
+            rotateNeeded = false
         ) ?: return null
 
         val croppedBitmap =
@@ -127,7 +121,10 @@ class ImageGenerateRepositoryImpl(
 
             if (rotateNeeded) {
                 val exifOrientation = ExifInterface(ByteArrayInputStream(byteArray))
-                    .getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
+                    .getAttributeInt(
+                        ExifInterface.TAG_ORIENTATION,
+                        ExifInterface.ORIENTATION_NORMAL
+                    )
 
                 rotateBitmap(decodedBitmap, exifOrientation)
             } else {

--- a/core/data/src/main/java/com/kolown/porring/core/data/repository/PostRepository.kt
+++ b/core/data/src/main/java/com/kolown/porring/core/data/repository/PostRepository.kt
@@ -23,6 +23,8 @@ import com.kolown.porring.core.data.repository.PostRepositoryImpl.Companion.GALL
 import com.kolown.porring.core.model.PageState
 import com.kolown.porring.core.model.PostContentModel
 import com.kolown.porring.core.model.Reactions
+import com.kolown.porring.core.model.UploadFeedBack
+import com.kolown.porring.core.model.UploadModel
 import com.kolown.porring.core.model.toReactions
 import com.kolown.porring.core.network.AuthDataSource
 import com.kolown.porring.core.network.FollowDataSource
@@ -30,13 +32,16 @@ import com.kolown.porring.core.network.ImageDataSource
 import com.kolown.porring.core.network.PostDataSource
 import com.kolown.porring.core.network.ReactionDataSource
 import com.kolown.porring.core.network.TagDataSource
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -46,7 +51,8 @@ import javax.inject.Inject
 import javax.inject.Named
 
 interface PostRepository {
-    suspend fun uploadPost(fileUri: Uri, description: String, tags: List<String>): Result<Unit>
+    fun getUploadFeedBack(): Flow<UploadFeedBack>
+    fun uploadPost(fileUri: Uri, description: String, tags: List<String>)
     fun getRandomDetailPostList(): Flow<PagingData<PostContentModel>>
     suspend fun reactPost(postId: String, reaction: Reactions): Result<Unit>
     suspend fun removePostReaction(postId: String, reaction: Reactions): Result<Unit>
@@ -77,6 +83,9 @@ class PostRepositoryImpl @Inject constructor(
     private val userDetailRemoteMediatorFactory: UserDetailRemoteMediatorFactory,
     private val userGalleryRemoteMediatorFactory: UserGalleryPostRemoteMediatorFactory,
 ) : PostRepository {
+    private val _uploadFeedBack = MutableSharedFlow<UploadFeedBack>()
+    override fun getUploadFeedBack(): Flow<UploadFeedBack> = _uploadFeedBack.asSharedFlow()
+
     override fun getUserPosts(userId: String?): Flow<PagingData<PostContentModel>> {
         val authorId = googleAuthDataSource.getUserId()
         val initialKey = if (userId == null) {
@@ -103,13 +112,15 @@ class PostRepositoryImpl @Inject constructor(
         ).flow
     }
 
-    override suspend fun uploadPost(
+    override fun uploadPost(
         fileUri: Uri,
         description: String,
         tags: List<String>,
-    ): Result<Unit> {
-        return runCatching {
-            coroutineScope {
+    ) {
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                _uploadFeedBack.emit(UploadFeedBack.Uploading)
+
                 val authorId = googleAuthDataSource.getUserId()
 
                 val postIdDeferred = async {
@@ -144,6 +155,17 @@ class PostRepositoryImpl @Inject constructor(
                         }
                     }.getOrThrow()
                 }
+                _uploadFeedBack.emit(UploadFeedBack.Success)
+            } catch (e: Exception) {
+                _uploadFeedBack.emit(
+                    UploadFeedBack.Error(
+                        UploadModel(
+                            fileUri.toString(),
+                            description,
+                            tags
+                        )
+                    )
+                )
             }
         }
     }

--- a/core/model/src/main/java/com/kolown/porring/core/model/SnackBarEvent.kt
+++ b/core/model/src/main/java/com/kolown/porring/core/model/SnackBarEvent.kt
@@ -4,6 +4,7 @@ package com.kolown.porring.core.model
 sealed class SnackBarEvent {
     abstract val message: String
     abstract val actionLabel: String?
+    open val onAction: (() -> Unit)? = null
 
     class LoginRequired : SnackBarEvent() {
         override val message: String = "로그인 후 이용 가능한 서비스입니다."
@@ -13,5 +14,6 @@ sealed class SnackBarEvent {
     data class Message(
         override val message: String,
         override val actionLabel: String?,
+        override val onAction: (() -> Unit)? = null
     ) : SnackBarEvent()
 }

--- a/core/model/src/main/java/com/kolown/porring/core/model/UploadFeedBack.kt
+++ b/core/model/src/main/java/com/kolown/porring/core/model/UploadFeedBack.kt
@@ -1,0 +1,7 @@
+package com.kolown.porring.core.model
+
+sealed class UploadFeedBack {
+    data object Uploading : UploadFeedBack()
+    data object Success : UploadFeedBack()
+    data class Error(val uploadModel: UploadModel) : UploadFeedBack()
+}

--- a/core/model/src/main/java/com/kolown/porring/core/model/UploadModel.kt
+++ b/core/model/src/main/java/com/kolown/porring/core/model/UploadModel.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class UploadModel(
-    val imgUri: String,
-    val description: String,
-    val categoryItems: List<String>
+    val imgUri: String = "",
+    val description: String = "",
+    val categoryItems: List<String> = emptyList()
 )

--- a/feature/camera/src/main/java/com/kolown/porring/feature/camera/screen/CameraScreenViewModel.kt
+++ b/feature/camera/src/main/java/com/kolown/porring/feature/camera/screen/CameraScreenViewModel.kt
@@ -31,8 +31,6 @@ class CameraScreenViewModel @Inject constructor(
             )
             _uri.value = imageGenerateRepository.saveBitmapToCache(bitmap!!)
         }
-//        TODO 이미지 편집 화면 나오면 그냥 uri 넘겨도 됨.(어차피 이미지 편집 화면에서 크롭할 예정)
-//        _uri.value = uri
     }
 
     fun saveBitmapToCache(bitmap: Bitmap) {

--- a/feature/image-edit/src/main/java/com/kolown/porring/feature/imageedit/ImageEditScreen.kt
+++ b/feature/image-edit/src/main/java/com/kolown/porring/feature/imageedit/ImageEditScreen.kt
@@ -57,6 +57,7 @@ import com.kolown.porring.core.designsystem.component.PorringIconButton
 import com.kolown.porring.core.designsystem.component.PorringTopAppBar
 import com.kolown.porring.core.designsystem.ui.theme.Primary
 import com.kolown.porring.core.ui.R.drawable
+import com.kolown.porring.feature.imageedit.component.boundedTransformGestures
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -176,73 +177,15 @@ private fun ImageEditScreen(
                         }
                     }
                 }
-                .pointerInput(boxSize, imageSize, minScale) {
-                    awaitPointerEventScope {
-                        while (true) {
-                            val event = awaitPointerEvent()
-
-                            if (event.type == PointerEventType.Release) {
-                                coroutineScope.launch {
-                                    if (scale.value < minScale) {
-                                        val scaleJob = async {
-                                            scale.animateTo(
-                                                minScale,
-                                                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
-                                            )
-                                        }
-                                        val offsetXJob = async {
-                                            offsetX.animateTo(
-                                                0f,
-                                                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
-                                            )
-                                        }
-                                        val offsetYJob = async {
-                                            offsetY.animateTo(
-                                                0f,
-                                                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
-                                            )
-                                        }
-
-                                        awaitAll(scaleJob, offsetXJob, offsetYJob)
-                                    }
-
-                                    if (scale.value > 5f) {
-                                        scale.animateTo(
-                                            5f,
-                                            animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
-                                        )
-                                    }
-
-                                    val boundedOffset = getBoundedOffset(
-                                        scale.value,
-                                        boxSize,
-                                        imageSize,
-                                        Offset(offsetX.value, offsetY.value)
-                                    )
-
-                                    val offsetXJob = async {
-                                        offsetX.animateTo(
-                                            boundedOffset.x,
-                                            animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
-                                        )
-                                    }
-
-                                    val offsetYJob = async {
-                                        offsetY.animateTo(
-                                            boundedOffset.y,
-                                            animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
-                                        )
-                                    }
-
-                                    awaitAll(
-                                        offsetXJob,
-                                        offsetYJob
-                                    )
-                                }
-                            }
-                        }
-                    }
-                },
+                .boundedTransformGestures(
+                    coroutineScope = coroutineScope,
+                    scale = scale,
+                    offsetX = offsetX,
+                    offsetY = offsetY,
+                    minScale = minScale,
+                    boxSize = boxSize,
+                    imageSize = imageSize
+                ),
             contentAlignment = Alignment.Center
         ) {
             AsyncImage(
@@ -359,24 +302,6 @@ private fun calcMinScale(boxSize: Size, imageSize: Size): Float {
     val (boxW, boxH) = boxSize
     val (imgW, imgH) = imageSize
     return if ((imgW / imgH) > (boxW / boxH)) boxH / imgH else boxW / imgW
-}
-
-private fun getBoundedOffset(
-    scale: Float,
-    boxSize: Size,
-    imageSize: Size,
-    currentOffset: Offset
-): Offset {
-    val scaledWidth = imageSize.width * scale
-    val scaledHeight = imageSize.height * scale
-
-    val maxOffsetX = ((scaledWidth - boxSize.width) / 2f).coerceAtLeast(0f)
-    val maxOffsetY = ((scaledHeight - boxSize.height) / 2f).coerceAtLeast(0f)
-
-    return Offset(
-        currentOffset.x.coerceIn(-maxOffsetX, maxOffsetX),
-        currentOffset.y.coerceIn(-maxOffsetY, maxOffsetY)
-    )
 }
 
 enum class CropRatio(val ratio: Float) { PORTRAIT(4f / 5f), LANDSCAPE(5f / 4f) }

--- a/feature/image-edit/src/main/java/com/kolown/porring/feature/imageedit/ImageEditScreen.kt
+++ b/feature/image-edit/src/main/java/com/kolown/porring/feature/imageedit/ImageEditScreen.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.core.AnimationVector1D
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -74,8 +73,8 @@ internal fun ImageEditRoute(
     val editedUri by viewModel.imageUri.collectAsStateWithLifecycle()
 
     var cropRatio by remember { mutableStateOf(CropRatio.PORTRAIT) }
-    val boxSize = remember { mutableStateOf(Size.Zero) }
-    val imageSize = remember { mutableStateOf(Size.Zero) }
+    var boxSize by remember { mutableStateOf(Size.Zero) }
+    var imageSize by remember { mutableStateOf(Size.Zero) }
     var minScale by remember { mutableFloatStateOf(1f) }
 
     val scale = remember { Animatable(1f) }
@@ -96,8 +95,8 @@ internal fun ImageEditRoute(
         padding = padding,
         imgUri = imgUri,
         minScale = minScale,
-        boxSize = boxSize.value,
-        imageSize = imageSize.value,
+        boxSize = boxSize,
+        imageSize = imageSize,
         cropRatio = cropRatio,
         coroutineScope = coroutineScope,
         scale = scale,
@@ -109,16 +108,15 @@ internal fun ImageEditRoute(
                 scale.value,
                 offsetX.value,
                 offsetY.value,
-                boxSize.value,
-                imageSize.value
+                boxSize,
+                imageSize
             )
         },
         navigateToHome = navigateToHome,
-        updateBoxSize = { boxSize.value = it },
-        updateImageSize = { imageSize.value = it },
+        updateBoxSize = { boxSize = it },
+        updateImageSize = { imageSize = it },
         updateMinScale = { minScale = it },
         updateCropRatio = { cropRatio = it },
-        getBoundedOffset = viewModel::getBoundedOffset
     )
 }
 
@@ -139,8 +137,7 @@ private fun ImageEditScreen(
     updateBoxSize: (Size) -> Unit = { },
     updateImageSize: (Size) -> Unit = { },
     updateMinScale: (Float) -> Unit = { },
-    updateCropRatio: (CropRatio) -> Unit = { },
-    getBoundedOffset: (Float, Float, Float, Float) -> Float = { _, _, _, _ -> 0f }
+    updateCropRatio: (CropRatio) -> Unit = { }
 ) {
     Column(
         modifier = Modifier
@@ -179,7 +176,7 @@ private fun ImageEditScreen(
                         }
                     }
                 }
-                .pointerInput(minScale) {
+                .pointerInput(boxSize, imageSize, minScale) {
                     awaitPointerEventScope {
                         while (true) {
                             val event = awaitPointerEvent()
@@ -216,42 +213,30 @@ private fun ImageEditScreen(
                                         )
                                     }
 
-                                    val boundedX = getBoundedOffset(
+                                    val boundedOffset = getBoundedOffset(
                                         scale.value,
-                                        offsetX.value,
-                                        boxSize.width,
-                                        imageSize.width
-                                    )
-                                    val boundedY = getBoundedOffset(
-                                        scale.value,
-                                        offsetY.value,
-                                        boxSize.height,
-                                        imageSize.height
+                                        boxSize,
+                                        imageSize,
+                                        Offset(offsetX.value, offsetY.value)
                                     )
 
-                                    val offsetXJob = if (boundedX != offsetX.value) {
-                                        async {
-                                            offsetX.animateTo(
-                                                boundedX,
-                                                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
-                                            )
-                                        }
-                                    } else null
+                                    val offsetXJob = async {
+                                        offsetX.animateTo(
+                                            boundedOffset.x,
+                                            animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
+                                        )
+                                    }
 
-                                    val offsetYJob = if (boundedY != offsetY.value) {
-                                        async {
-                                            offsetY.animateTo(
-                                                boundedY,
-                                                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
-                                            )
-                                        }
-                                    } else null
+                                    val offsetYJob = async {
+                                        offsetY.animateTo(
+                                            boundedOffset.y,
+                                            animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
+                                        )
+                                    }
 
                                     awaitAll(
-                                        *(listOfNotNull(
-                                            offsetXJob,
-                                            offsetYJob
-                                        ).toTypedArray())
+                                        offsetXJob,
+                                        offsetYJob
                                     )
                                 }
                             }
@@ -272,18 +257,7 @@ private fun ImageEditScreen(
                         translationY = offsetY.value
                     ),
                 model = imgUri,
-                contentDescription = "Selected Image",
-                onSuccess = {
-                    coroutineScope.launch {
-                        val imgWidth = it.result.image.width.toFloat()
-                        val imgHeight = it.result.image.height.toFloat()
-
-                        val computedMinScale = calcMinScale(boxSize, Size(imgWidth, imgHeight))
-
-                        updateMinScale(computedMinScale)
-                        scale.snapTo(computedMinScale)
-                    }
-                }
+                contentDescription = "Selected Image"
             )
 
             GridBox(
@@ -318,7 +292,8 @@ private fun GridBox(
             .fillMaxHeight()
             .aspectRatio(cropRatio.ratio)
             .onSizeChanged { size ->
-                updateBoxSize(Size(size.width.toFloat(), size.height.toFloat()))
+                updateBoxSize(size.toSize())
+
                 coroutineScope.launch {
                     val computedMinScale = calcMinScale(size.toSize(), imageSize)
 
@@ -384,6 +359,24 @@ private fun calcMinScale(boxSize: Size, imageSize: Size): Float {
     val (boxW, boxH) = boxSize
     val (imgW, imgH) = imageSize
     return if ((imgW / imgH) > (boxW / boxH)) boxH / imgH else boxW / imgW
+}
+
+private fun getBoundedOffset(
+    scale: Float,
+    boxSize: Size,
+    imageSize: Size,
+    currentOffset: Offset
+): Offset {
+    val scaledWidth = imageSize.width * scale
+    val scaledHeight = imageSize.height * scale
+
+    val maxOffsetX = ((scaledWidth - boxSize.width) / 2f).coerceAtLeast(0f)
+    val maxOffsetY = ((scaledHeight - boxSize.height) / 2f).coerceAtLeast(0f)
+
+    return Offset(
+        currentOffset.x.coerceIn(-maxOffsetX, maxOffsetX),
+        currentOffset.y.coerceIn(-maxOffsetY, maxOffsetY)
+    )
 }
 
 enum class CropRatio(val ratio: Float) { PORTRAIT(4f / 5f), LANDSCAPE(5f / 4f) }

--- a/feature/image-edit/src/main/java/com/kolown/porring/feature/imageedit/ImageEditViewModel.kt
+++ b/feature/image-edit/src/main/java/com/kolown/porring/feature/imageedit/ImageEditViewModel.kt
@@ -1,5 +1,6 @@
 package com.kolown.porring.feature.imageedit
 
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -39,10 +40,5 @@ class ImageEditViewModel @Inject constructor(
 
             _imageUri.value = editedUri
         }
-    }
-
-    fun getBoundedOffset(scale: Float, offset: Float, boxSize: Float, imageSize: Float): Float {
-        val maxOffset = maxOf(((imageSize * scale) - boxSize) / 2, 0f)
-        return offset.coerceIn(-maxOffset, maxOffset)
     }
 }

--- a/feature/image-edit/src/main/java/com/kolown/porring/feature/imageedit/component/boundedTransformGestures.kt
+++ b/feature/image-edit/src/main/java/com/kolown/porring/feature/imageedit/component/boundedTransformGestures.kt
@@ -1,0 +1,106 @@
+package com.kolown.porring.feature.imageedit.component
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.pointerInput
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
+
+internal fun Modifier.boundedTransformGestures(
+    coroutineScope: CoroutineScope,
+    scale: Animatable<Float, AnimationVector1D>,
+    offsetX: Animatable<Float, AnimationVector1D>,
+    offsetY: Animatable<Float, AnimationVector1D>,
+    minScale: Float,
+    boxSize: Size,
+    imageSize: Size
+): Modifier = this.pointerInput(boxSize, imageSize, minScale) {
+    awaitPointerEventScope {
+        while (true) {
+            val event = awaitPointerEvent()
+
+            if (event.type == PointerEventType.Release) {
+                coroutineScope.launch {
+                    if (scale.value < minScale) {
+                        val scaleJob = async {
+                            scale.animateTo(
+                                minScale,
+                                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
+                            )
+                        }
+                        val offsetXJob = async {
+                            offsetX.animateTo(
+                                0f,
+                                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
+                            )
+                        }
+                        val offsetYJob = async {
+                            offsetY.animateTo(
+                                0f,
+                                animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
+                            )
+                        }
+
+                        awaitAll(scaleJob, offsetXJob, offsetYJob)
+                    }
+
+                    if (scale.value > 5f) {
+                        scale.animateTo(
+                            5f,
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
+                        )
+                    }
+
+                    val boundedOffset = getBoundedOffset(
+                        scale.value,
+                        boxSize,
+                        imageSize,
+                        Offset(offsetX.value, offsetY.value)
+                    )
+
+                    val offsetXJob = async {
+                        offsetX.animateTo(
+                            boundedOffset.x,
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
+                        )
+                    }
+
+                    val offsetYJob = async {
+                        offsetY.animateTo(
+                            boundedOffset.y,
+                            animationSpec = spring(dampingRatio = Spring.DampingRatioLowBouncy)
+                        )
+                    }
+
+                    awaitAll(offsetXJob, offsetYJob)
+                }
+            }
+        }
+    }
+}
+
+private fun getBoundedOffset(
+    scale: Float,
+    boxSize: Size,
+    imageSize: Size,
+    currentOffset: Offset
+): Offset {
+    val scaledWidth = imageSize.width * scale
+    val scaledHeight = imageSize.height * scale
+
+    val maxOffsetX = ((scaledWidth - boxSize.width) / 2f).coerceAtLeast(0f)
+    val maxOffsetY = ((scaledHeight - boxSize.height) / 2f).coerceAtLeast(0f)
+
+    return Offset(
+        currentOffset.x.coerceIn(-maxOffsetX, maxOffsetX),
+        currentOffset.y.coerceIn(-maxOffsetY, maxOffsetY)
+    )
+}

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/MainScreen.kt
@@ -34,6 +34,7 @@ import com.kolown.porring.core.ui.component.showSnackBarWithData
 import com.kolown.porring.feature.main.component.MainBottomBar
 import com.kolown.porring.feature.main.component.MainNavHost
 import com.kolown.porring.feature.main.component.PorringAlertDialog
+import com.kolown.porring.feature.main.model.SnackBarNavigation
 import com.kolown.porring.feature.main.navigation.MainMenu
 import com.kolown.porring.feature.main.navigation.MainNavigator
 import com.kolown.porring.feature.main.navigation.rememberMainNavigator
@@ -77,7 +78,23 @@ internal fun MainScreen(
                     }
                 }
 
-                is SnackBarEvent.Message -> Unit
+                is SnackBarEvent.Message -> {
+                    if (result == SnackbarResult.ActionPerformed) {
+                        it.onAction?.invoke()
+                    }
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        mainViewModel.navigationRequest.collect { nav ->
+            when (nav) {
+                SnackBarNavigation.ToGallery -> navigator.navigate(MainMenu.MY)
+                is SnackBarNavigation.ToUpload -> navigator.navigateToUpload(
+                    nav.uploadModel.imgUri,
+                    nav.uploadModel
+                )
             }
         }
     }

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/MainViewModel.kt
@@ -4,13 +4,17 @@ import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kolown.porring.core.data.repository.AuthRepository
+import com.kolown.porring.core.data.repository.PostRepository
 import com.kolown.porring.core.data.repository.RemoteConfigRepository
 import com.kolown.porring.core.model.SnackBarEvent
+import com.kolown.porring.core.model.UploadFeedBack
+import com.kolown.porring.feature.main.model.SnackBarNavigation
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -18,6 +22,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
+    postRepository: PostRepository,
     authRepository: AuthRepository,
     private val remoteConfigRepository: RemoteConfigRepository
 ) : ViewModel() {
@@ -36,7 +41,40 @@ class MainViewModel @Inject constructor(
     )
     val snackBarFlow = _snackBarFlow.asSharedFlow()
 
+    private val _navigationRequest = MutableSharedFlow<SnackBarNavigation>()
+    val navigationRequest: SharedFlow<SnackBarNavigation> = _navigationRequest.asSharedFlow()
+
     val loginState = authRepository.checkUserLoggedIn()
+
+    init {
+        viewModelScope.launch {
+            postRepository.getUploadFeedBack().collect { feedback ->
+                val event = when (feedback) {
+                    UploadFeedBack.Uploading -> SnackBarEvent.Message(
+                        "업로드 중입니다.",
+                        null
+                    )
+                    UploadFeedBack.Success -> SnackBarEvent.Message(
+                        "업로드 완료되었습니다.",
+                        "갤러리에서 확인하기"
+                    ) {
+                        viewModelScope.launch {
+                            _navigationRequest.emit(SnackBarNavigation.ToGallery)
+                        }
+                    }
+                    is UploadFeedBack.Error -> SnackBarEvent.Message(
+                        "업로드에 실패했습니다.",
+                        "업로드로 이동하기"
+                    ) {
+                        viewModelScope.launch {
+                            _navigationRequest.emit(SnackBarNavigation.ToUpload(feedback.uploadModel))
+                        }
+                    }
+                }
+                _snackBarFlow.emit(event)
+            }
+        }
+    }
 
     fun getVersionName() {
         viewModelScope.launch {

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/model/SnackBarNavigation.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/model/SnackBarNavigation.kt
@@ -1,0 +1,8 @@
+package com.kolown.porring.feature.main.model
+
+import com.kolown.porring.core.model.UploadModel
+
+sealed class SnackBarNavigation {
+    data object ToGallery : SnackBarNavigation()
+    data class ToUpload (val uploadModel: UploadModel) : SnackBarNavigation()
+}

--- a/feature/upload/src/main/java/com/kolown/porring/feature/upload/UploadScreen.kt
+++ b/feature/upload/src/main/java/com/kolown/porring/feature/upload/UploadScreen.kt
@@ -118,7 +118,7 @@ internal fun UploadRoute(
             imgUri
         },
         categoryItems = categoryItems,
-        uploadPost = { },
+        uploadPost = viewModel::uploadPost,
         addCategory = viewModel::addCategory,
         navigateToHome = navigateToHome,
         removeCategory = viewModel::removeCategory,

--- a/feature/upload/src/main/java/com/kolown/porring/feature/upload/UploadScreen.kt
+++ b/feature/upload/src/main/java/com/kolown/porring/feature/upload/UploadScreen.kt
@@ -67,14 +67,12 @@ internal fun UploadRoute(
     padding: PaddingValues,
     navigateToHome: () -> Unit,
 ) {
-    val description by viewModel.description.collectAsStateWithLifecycle()
-    val categoryItems by viewModel.categoryItems.collectAsStateWithLifecycle()
-    val webPUri by viewModel.webPUri.collectAsStateWithLifecycle()
+    val uploadState by viewModel.uploadState.collectAsStateWithLifecycle()
     val uploadEnable by viewModel.uploadEnable.collectAsStateWithLifecycle()
 
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
-    val previousSize = remember { mutableIntStateOf(categoryItems.size) }
+    val previousSize = remember { mutableIntStateOf(uploadState.categoryItems.size) }
 
     val scrollState = rememberScrollState()
     var imeHeightState by remember { mutableIntStateOf(0) }
@@ -96,28 +94,24 @@ internal fun UploadRoute(
         scrollState.scrollTo(imeHeight)
     }
 
-    LaunchedEffect(categoryItems.size) {
-        if (categoryItems.size > previousSize.intValue) {
+    LaunchedEffect(uploadState.categoryItems.size) {
+        if (uploadState.categoryItems.size > previousSize.intValue) {
             focusRequester.requestFocus()
         }
-        previousSize.intValue = categoryItems.size
+        previousSize.intValue = uploadState.categoryItems.size
     }
 
     UploadScreen(
         imeHeightState = imeHeightState,
-        description = description,
+        description = uploadState.description,
         uploadEnable = uploadEnable,
         isDescriptionMax = isDescriptionMax,
         padding = padding,
         scrollState = scrollState,
         focusManager = focusManager,
         focusRequester = focusRequester,
-        imgUri = if (imgUri == "") {
-            webPUri.toString()
-        } else {
-            imgUri
-        },
-        categoryItems = categoryItems,
+        imgUri = imgUri.ifBlank { uploadState.imgUri },
+        categoryItems = uploadState.categoryItems,
         uploadPost = viewModel::uploadPost,
         addCategory = viewModel::addCategory,
         navigateToHome = navigateToHome,

--- a/feature/upload/src/main/java/com/kolown/porring/feature/upload/UploadViewModel.kt
+++ b/feature/upload/src/main/java/com/kolown/porring/feature/upload/UploadViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.kolown.porring.core.data.repository.ImageGenerateRepository
+import com.kolown.porring.core.data.repository.PostRepository
 import com.kolown.porring.core.model.UploadModel
 import com.kolown.porring.core.navigation.Route
 import com.kolown.porring.feature.upload.navigation.UploadType
@@ -25,6 +26,7 @@ import kotlin.reflect.typeOf
 @HiltViewModel
 class UploadViewModel @Inject constructor(
     private val repository: ImageGenerateRepository,
+    private val postRepository: PostRepository,
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
     private val _description = MutableStateFlow("")
@@ -93,6 +95,14 @@ class UploadViewModel @Inject constructor(
                 _webPUri.value = repository.saveBitmapToCache(it, Bitmap.CompressFormat.WEBP, 80)
             }
         }
+    }
+
+    fun uploadPost() {
+        postRepository.uploadPost(
+            fileUri = webPUri.value!!,
+            description = description.value,
+            tags = categoryItems.value
+        )
     }
 
     private fun setUploadData() {

--- a/feature/upload/src/main/java/com/kolown/porring/feature/upload/UploadViewModel.kt
+++ b/feature/upload/src/main/java/com/kolown/porring/feature/upload/UploadViewModel.kt
@@ -2,12 +2,12 @@ package com.kolown.porring.feature.upload
 
 import android.graphics.Bitmap
 import android.net.Uri
-import android.util.Log
 import androidx.core.net.toUri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.kolown.porring.core.common.retry
 import com.kolown.porring.core.data.repository.ImageGenerateRepository
 import com.kolown.porring.core.data.repository.PostRepository
 import com.kolown.porring.core.model.UploadModel
@@ -17,9 +17,11 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.IOException
 import javax.inject.Inject
 import kotlin.reflect.typeOf
 
@@ -29,86 +31,77 @@ class UploadViewModel @Inject constructor(
     private val postRepository: PostRepository,
     private val savedStateHandle: SavedStateHandle,
 ) : ViewModel() {
-    private val _description = MutableStateFlow("")
-    val description = _description.asStateFlow()
+    private val _uploadState = MutableStateFlow(UploadModel())
+    val uploadState = _uploadState.asStateFlow()
 
-    private val _categoryItems = MutableStateFlow<List<String>>(emptyList())
-    val categoryItems = _categoryItems.asStateFlow()
-
-    private val _webPUri = MutableStateFlow<Uri?>(null)
-    val webPUri = _webPUri.asStateFlow()
-
-    private val typeMap = mapOf(
-        typeOf<UploadModel>() to UploadType,
-    )
-
-    init {
-        setUploadData()
-    }
-
-    val uploadEnable = combine(
-        _description, _categoryItems, _webPUri
-    ) { description, categoryItems, webPUri ->
-        description.isNotEmpty() && categoryItems.none { it.isBlank() } && webPUri != null
+    val uploadEnable = uploadState.map { state ->
+        state.description.isNotBlank() && state.categoryItems.isNotEmpty() && state.imgUri.isNotBlank()
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5000),
         initialValue = false
     )
 
+    init {
+        _uploadState.value = extractUploadModel()
+    }
+
     fun changeDescription(description: String) {
-        _description.value = description
+        _uploadState.update { it.copy(description = description) }
     }
 
     fun addCategory() {
-        _categoryItems.value += ""
+        _uploadState.update { it.copy(categoryItems = it.categoryItems + "") }
+    }
+
+    fun removeCategory(name: String) {
+        _uploadState.update { model ->
+            model.copy(categoryItems = model.categoryItems.filterNot { it == name })
+        }
     }
 
     fun changeCategoryName(index: Int, name: String) {
-        val newList = _categoryItems.value.toMutableList()
-
-        newList[index] = name
-        _categoryItems.value = newList
-    }
-
-    fun removeCategory(category: String) {
-        _categoryItems.value = _categoryItems.value.filterNot { it == category }
+        _uploadState.update { state ->
+            val newCategories = state.categoryItems.toMutableList().apply {
+                if (index in indices) this[index] = name
+            }
+            state.copy(categoryItems = newCategories)
+        }
     }
 
     fun getUriWebP(uri: String) {
         viewModelScope.launch {
-            var retries = 0
-            val maxRetries = 3
-            var bitmap: Bitmap? = null
-
-            while (retries < maxRetries) {
-                bitmap = repository.decodeSampledBitmapFromUri(
+            val bitmap = retry(times = 3) {
+                repository.decodeSampledBitmapFromUri(
                     uri = Uri.parse(uri),
-                    resizeNeeded = false,
-                    rotateNeeded = false
-                )
-                if (bitmap != null) break
-                retries++
+                    resizeNeeded = true,
+                    rotateNeeded = true
+                ) ?: throw IOException("Decode Failed")
             }
 
-            bitmap?.let {
-                _webPUri.value = repository.saveBitmapToCache(it, Bitmap.CompressFormat.WEBP, 80)
+            val webPUri = repository.saveBitmapToCache(
+                bitmap,
+                Bitmap.CompressFormat.WEBP,
+                80
+            ) ?: return@launch
+
+            _uploadState.update {
+                it.copy(
+                    imgUri = webPUri.toString()
+                )
             }
         }
     }
 
     fun uploadPost() {
         postRepository.uploadPost(
-            fileUri = webPUri.value!!,
-            description = description.value,
-            tags = categoryItems.value
+            fileUri = uploadState.value.imgUri.toUri(),
+            description = uploadState.value.description,
+            tags = uploadState.value.categoryItems
         )
     }
 
-    private fun setUploadData() {
-        val uploadModel = savedStateHandle.toRoute<Route.Upload>(typeMap).uploadModel
-        _description.value = uploadModel.description
-        _categoryItems.value = uploadModel.categoryItems
-        _webPUri.value = uploadModel.imgUri.toUri()
+    private fun extractUploadModel(): UploadModel {
+        return savedStateHandle.toRoute<Route.Upload>(mapOf(typeOf<UploadModel>() to UploadType)).uploadModel
     }
 }


### PR DESCRIPTION
## 📝작업 내용
- Upload 연동
- UploadViewModel 상태 단일화
- 이미지 편집 오류 수정
## 작업 상세
### Upload 연동
![image](https://github.com/user-attachments/assets/2a46ab4a-b6a8-4ac6-89a1-d6ca5ddc6cf6)
PostRepository를 hilt에서 singleton 객체로 생성하여 main과 upload가 공유하도록 함.
upload를 실행하면 로딩, 성공, 실패에 따라서 SharedFlow를 통해 Main으로 이벤트 전달하게 구현.

### UploadViewModel 상태 단일화
기존에 description, categoryItems, uri가 다 따로 stateFlow로 나눠져서 관리했으나 보일러플레이트라고 판단함.
repository에서 UploadModel로 넘겨주고 있으므로 UploadModel로 uploadState를 만들어 하나로 관리하도록 수정

### 이미지 편집 오류 수정

https://github.com/user-attachments/assets/022dd578-4f25-44f9-b209-67bf14a863c1

기존에 영상과 같이 비율이 정상 작동하지 않는 오류가 있었음.
ex) 처음에 5:4로 설정 ⇒ 이후에 4:5로 설정 ⇒ bounded가 5:4로 계산되어 cropBox 범위를 벗어남
ex) 처음에 4:5로 설정 ⇒ 이후에 5:4로 설정 ⇒ bounded가 4:5로 계산되어 cropBox 범위로 들어오지 못함

처음에는 boundedOffset을 계산하는 함수의 문제인 것으로 판단했으나 가장 최신에 구현한 함수로 변경했으나 동일한 현상 발생함.

```kotlin
        updateBoxSize = { boxSize = it },
```
따라서 boxSize를 변경하는 위치와 boundedOffset을 계산하는 위치에서 boxSize를 로그로 찍어봤음.
=> 계산하는 위치에서 **처음에 지정한 boxSize가 출력되는 것을 확인**함.

`pointerInput` 블럭은 **Composable이 아닌 Coroutine context 안에서 작동**하고 있으며, `boxSize` 나 `imageSize` 가 바뀌더라도 그 블록 자체가 재실행되지 않는다.
즉, `pointerInput` 내에서 참조된 `boxSize` 는 변경 전의 캡처된 값이기 때문에 발생하는 문제이다.

⇒ Kotlin Compose에서 흔히 겪는 **closure capture** 문제

```kotlin
.pointerInput(boxSize, imageSize, minScale) {
    awaitPointerEventScope {
        while (true) {
```
`pointerInput`을 boxSize와 imageSize도 의존하게 수정했다.
이렇게 하면 boxSize나 imageSize가 변경될 때 **pointerInput 블록이 재구성**되어 최신 값을 캡처하게 된다.

## ✅ TODO
- 테스트를 계속 진행하면서 Camera의 성능을 높일 필요가 있음을 계속해서 체감합니다.
- 이후에 ImageGenerate 로직에서 FileDescriptor를 도입할 것을 고려해보는 것도 좋을 것 같습니다.
