### PR TITLE
Color, Typo 시스템 추가

### DIFF
--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/component/PorringTopAppBar.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/component/PorringTopAppBar.kt
@@ -6,13 +6,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.kolown.porring.core.designsystem.ui.theme.PorringTheme
 
 @Composable
 fun PorringTopAppBar(
@@ -39,7 +39,7 @@ fun PorringTopAppBar(
 
             title?.let {
                 Text(
-                    style = MaterialTheme.typography.titleLarge,
+                    style = PorringTheme.typography.headline,
                     text = title,
                     modifier = Modifier.padding(start = 16.dp)
                 )

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Color.kt
@@ -18,3 +18,91 @@ val PrimaryUnActiveDark = Color(0xFF8D8D8D)
 val SnackBarContainer = Color(0xFF363535)
 val ShimmerLightGray = Color(0xFFBFBFBF) // 중간 연한 그레이
 val ShimmerDarkGray = Color(0xFFADADAD) // 중간 진한 그레이
+
+interface PorringColor {
+    val Primary: Color
+    val OnPrimary: Color
+    val PrimaryContainer: Color
+    val OnPrimaryContainer: Color
+    val Secondary: Color
+    val Tertiary: Color
+    val OnSecondary: Color
+    val OnTertiary: Color
+    val SecondaryContainer: Color
+    val TertiaryContainer: Color
+    val OnSecondaryContainer: Color
+    val OnTertiaryContainer: Color
+    val Background: Color
+    val Outline: Color
+    val Error: Color
+    val OnBackground: Color
+    val OutlineVariant: Color
+    val OnError: Color
+    val Surface: Color
+    val Shadow: Color
+    val ErrorContainer: Color
+    val OnSurface: Color
+    val OnErrorContainer: Color
+}
+
+internal object PorringLightColor : PorringColor {
+    override val Primary = Color(0xFF598AFF)
+    override val OnPrimary = Color(0xFFFFFFFF)
+    override val PrimaryContainer = Color(0xFFC9DBFF)
+    override val OnPrimaryContainer = Color(0xFF102A54)
+
+    override val Secondary = Color(0xFF444655)
+    override val OnSecondary = Color(0xFFFFFFFF)
+    override val SecondaryContainer = Color(0xFFD4D6E8)
+    override val OnSecondaryContainer = Color(0xFF272937)
+
+    override val Tertiary = Color(0xFFD0D7FF)
+    override val OnTertiary = Color(0xFFF7F8FF)
+    override val TertiaryContainer = Color(0xFFCDD5FF)
+    override val OnTertiaryContainer = Color(0xFF112650)
+
+    override val Background = Color(0xFFF7F8FF)
+    override val OnBackground = Color(0xFF1E2230)
+    override val Surface = Color(0xFFFFFFFF)
+    override val OnSurface = Color(0xFF1E2230)
+
+    override val Outline = Color(0xFFC7CDD8)
+    override val OutlineVariant = Color(0xFFE2E6ED)
+    override val Shadow = Color(0xFFCCCCCC)
+
+    override val Error = Color(0xFFF75670)
+    override val OnError = Color(0xFFFFFFFF)
+    override val ErrorContainer = Color(0xFFFFC9DA)
+    override val OnErrorContainer = Color(0xFF89001F)
+}
+
+internal object PorringDarkColor : PorringColor {
+    override val Primary = Color(0xFF7DAEFF)
+    override val OnPrimary = Color(0xFF002449)
+    override val PrimaryContainer = Color(0xFF598AFF)
+    override val OnPrimaryContainer = Color(0xFFE2ECFF)
+
+    override val Secondary = Color(0xFFC2C6D4)
+    override val OnSecondary = Color(0xFF2D2F36)
+    override val SecondaryContainer = Color(0xFF50525B)
+    override val OnSecondaryContainer = Color(0xFFE7E9F4)
+
+    override val Tertiary = Color(0xFF5F678D)
+    override val OnTertiary = Color(0xFF2B3152)
+    override val TertiaryContainer = Color(0xFF535A7A)
+    override val OnTertiaryContainer = Color(0xFFE8EAFF)
+
+    override val Background = Color(0xFF0D0E11)
+    override val OnBackground = Color(0xFFB4B6BA)
+    override val Surface = Color(0xFF1A1B20)
+    override val OnSurface = Color(0xFFE5E7EC)
+
+    override val Outline = Color(0xFF8A8D99)
+    override val OutlineVariant = Color(0xFF3C3E44)
+    override val Shadow = Color(0xFF0C0C0D)
+
+    override val Error = Color(0xFFFFB4AB)
+    override val OnError = Color(0xFF690005)
+    override val ErrorContainer = Color(0xFF93000A)
+    override val OnErrorContainer = Color(0xFFFFDAD6)
+}

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Color.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Color.kt
@@ -20,89 +20,89 @@ val ShimmerLightGray = Color(0xFFBFBFBF) // 중간 연한 그레이
 val ShimmerDarkGray = Color(0xFFADADAD) // 중간 진한 그레이
 
 interface PorringColor {
-    val Primary: Color
-    val OnPrimary: Color
-    val PrimaryContainer: Color
-    val OnPrimaryContainer: Color
-    val Secondary: Color
-    val Tertiary: Color
-    val OnSecondary: Color
-    val OnTertiary: Color
-    val SecondaryContainer: Color
-    val TertiaryContainer: Color
-    val OnSecondaryContainer: Color
-    val OnTertiaryContainer: Color
-    val Background: Color
-    val Outline: Color
-    val Error: Color
-    val OnBackground: Color
-    val OutlineVariant: Color
-    val OnError: Color
-    val Surface: Color
-    val Shadow: Color
-    val ErrorContainer: Color
-    val OnSurface: Color
-    val OnErrorContainer: Color
+    val primary: Color
+    val onPrimary: Color
+    val primaryContainer: Color
+    val onPrimaryContainer: Color
+    val secondary: Color
+    val tertiary: Color
+    val onSecondary: Color
+    val onTertiary: Color
+    val secondaryContainer: Color
+    val tertiaryContainer: Color
+    val onSecondaryContainer: Color
+    val onTertiaryContainer: Color
+    val background: Color
+    val outline: Color
+    val error: Color
+    val onBackground: Color
+    val outlineVariant: Color
+    val onError: Color
+    val surface: Color
+    val shadow: Color
+    val errorContainer: Color
+    val onSurface: Color
+    val onErrorContainer: Color
 }
 
 internal object PorringLightColor : PorringColor {
-    override val Primary = Color(0xFF598AFF)
-    override val OnPrimary = Color(0xFFFFFFFF)
-    override val PrimaryContainer = Color(0xFFC9DBFF)
-    override val OnPrimaryContainer = Color(0xFF102A54)
+    override val primary = Color(0xFF598AFF)
+    override val onPrimary = Color(0xFFFFFFFF)
+    override val primaryContainer = Color(0xFFC9DBFF)
+    override val onPrimaryContainer = Color(0xFF102A54)
 
-    override val Secondary = Color(0xFF444655)
-    override val OnSecondary = Color(0xFFFFFFFF)
-    override val SecondaryContainer = Color(0xFFD4D6E8)
-    override val OnSecondaryContainer = Color(0xFF272937)
+    override val secondary = Color(0xFF444655)
+    override val onSecondary = Color(0xFFFFFFFF)
+    override val secondaryContainer = Color(0xFFD4D6E8)
+    override val onSecondaryContainer = Color(0xFF272937)
 
-    override val Tertiary = Color(0xFFD0D7FF)
-    override val OnTertiary = Color(0xFFF7F8FF)
-    override val TertiaryContainer = Color(0xFFCDD5FF)
-    override val OnTertiaryContainer = Color(0xFF112650)
+    override val tertiary = Color(0xFFD0D7FF)
+    override val onTertiary = Color(0xFFF7F8FF)
+    override val tertiaryContainer = Color(0xFFCDD5FF)
+    override val onTertiaryContainer = Color(0xFF112650)
 
-    override val Background = Color(0xFFF7F8FF)
-    override val OnBackground = Color(0xFF1E2230)
-    override val Surface = Color(0xFFFFFFFF)
-    override val OnSurface = Color(0xFF1E2230)
+    override val background = Color(0xFFF7F8FF)
+    override val onBackground = Color(0xFF1E2230)
+    override val surface = Color(0xFFFFFFFF)
+    override val onSurface = Color(0xFF1E2230)
 
-    override val Outline = Color(0xFFC7CDD8)
-    override val OutlineVariant = Color(0xFFE2E6ED)
-    override val Shadow = Color(0xFFCCCCCC)
+    override val outline = Color(0xFFC7CDD8)
+    override val outlineVariant = Color(0xFFE2E6ED)
+    override val shadow = Color(0xFFCCCCCC)
 
-    override val Error = Color(0xFFF75670)
-    override val OnError = Color(0xFFFFFFFF)
-    override val ErrorContainer = Color(0xFFFFC9DA)
-    override val OnErrorContainer = Color(0xFF89001F)
+    override val error = Color(0xFFF75670)
+    override val onError = Color(0xFFFFFFFF)
+    override val errorContainer = Color(0xFFFFC9DA)
+    override val onErrorContainer = Color(0xFF89001F)
 }
 
 internal object PorringDarkColor : PorringColor {
-    override val Primary = Color(0xFF7DAEFF)
-    override val OnPrimary = Color(0xFF002449)
-    override val PrimaryContainer = Color(0xFF598AFF)
-    override val OnPrimaryContainer = Color(0xFFE2ECFF)
+    override val primary = Color(0xFF7DAEFF)
+    override val onPrimary = Color(0xFF002449)
+    override val primaryContainer = Color(0xFF598AFF)
+    override val onPrimaryContainer = Color(0xFFE2ECFF)
 
-    override val Secondary = Color(0xFFC2C6D4)
-    override val OnSecondary = Color(0xFF2D2F36)
-    override val SecondaryContainer = Color(0xFF50525B)
-    override val OnSecondaryContainer = Color(0xFFE7E9F4)
+    override val secondary = Color(0xFFC2C6D4)
+    override val onSecondary = Color(0xFF2D2F36)
+    override val secondaryContainer = Color(0xFF50525B)
+    override val onSecondaryContainer = Color(0xFFE7E9F4)
 
-    override val Tertiary = Color(0xFF5F678D)
-    override val OnTertiary = Color(0xFF2B3152)
-    override val TertiaryContainer = Color(0xFF535A7A)
-    override val OnTertiaryContainer = Color(0xFFE8EAFF)
+    override val tertiary = Color(0xFF5F678D)
+    override val onTertiary = Color(0xFF2B3152)
+    override val tertiaryContainer = Color(0xFF535A7A)
+    override val onTertiaryContainer = Color(0xFFE8EAFF)
 
-    override val Background = Color(0xFF0D0E11)
-    override val OnBackground = Color(0xFFB4B6BA)
-    override val Surface = Color(0xFF1A1B20)
-    override val OnSurface = Color(0xFFE5E7EC)
+    override val background = Color(0xFF0D0E11)
+    override val onBackground = Color(0xFFB4B6BA)
+    override val surface = Color(0xFF1A1B20)
+    override val onSurface = Color(0xFFE5E7EC)
 
-    override val Outline = Color(0xFF8A8D99)
-    override val OutlineVariant = Color(0xFF3C3E44)
-    override val Shadow = Color(0xFF0C0C0D)
+    override val outline = Color(0xFF8A8D99)
+    override val outlineVariant = Color(0xFF3C3E44)
+    override val shadow = Color(0xFF0C0C0D)
 
-    override val Error = Color(0xFFFFB4AB)
-    override val OnError = Color(0xFF690005)
-    override val ErrorContainer = Color(0xFF93000A)
-    override val OnErrorContainer = Color(0xFFFFDAD6)
+    override val error = Color(0xFFFFB4AB)
+    override val onError = Color(0xFF690005)
+    override val errorContainer = Color(0xFF93000A)
+    override val onErrorContainer = Color(0xFFFFDAD6)
 }

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/LocalColor.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/LocalColor.kt
@@ -1,0 +1,7 @@
+package com.kolown.porring.core.designsystem.ui.theme
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+internal val LocalColor = staticCompositionLocalOf<PorringColor> {
+    error("LocalColor가 제공되지 않았습니다. PorringTheme를 적용했는지 확인해주세요.")
+}

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/LocalTypography.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/LocalTypography.kt
@@ -1,0 +1,7 @@
+package com.kolown.porring.core.designsystem.ui.theme
+
+import androidx.compose.runtime.staticCompositionLocalOf
+
+internal val LocalTypography = staticCompositionLocalOf<PorringTypography> {
+    error("LocalTypography가 제공되지 않았습니다. PorringTheme를 적용했는지 확인해주세요.")
+}

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
@@ -34,7 +33,6 @@ fun PorringTheme(
 ) {
     val colors: PorringColor = if (isDark) PorringDarkColor else PorringLightColor
 
-    val context = LocalContext.current
     val view = LocalView.current
 
     SideEffect {
@@ -51,6 +49,7 @@ fun PorringTheme(
 
     CompositionLocalProvider(
         LocalColor provides colors,
+        LocalTypography provides PorringTypography,
         content = content
     )
 }
@@ -58,4 +57,6 @@ fun PorringTheme(
 object PorringTheme {
     val colors: PorringColor
         @Composable get() = LocalColor.current
+    val typography: PorringTypography
+        @Composable get() = LocalTypography.current
 }

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
@@ -1,11 +1,9 @@
 package com.kolown.porring.core.designsystem.ui.theme
 
 import android.app.Activity
-import android.os.Build
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -31,14 +29,13 @@ private val LightColorScheme = lightColorScheme(
 @Composable
 fun PorringTheme(
     isLightBars: Boolean,
+    isDark: Boolean = false,
     content: @Composable () -> Unit,
 ) {
+    val colors: PorringColor = if (isDark) PorringDarkColor else PorringLightColor
+
     val context = LocalContext.current
     val view = LocalView.current
-    val colorScheme = when {
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> dynamicLightColorScheme(context)
-        else -> LightColorScheme
-    }
 
     SideEffect {
         val window = (view.context as Activity).window
@@ -48,12 +45,17 @@ fun PorringTheme(
         insetsController.isAppearanceLightStatusBars = isLightBars
         insetsController.isAppearanceLightNavigationBars = isLightBars
         window.statusBarColor = Color.Transparent.toArgb()
-        window.navigationBarColor =
-            if (isLightBars) Background.toArgb() else BackgroundDark.toArgb()
+        window.navigationBarColor = Color.Transparent.toArgb()
+//            if (isLightBars) Background.toArgb() else BackgroundDark.toArgb()
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
+    CompositionLocalProvider(
+        LocalColor provides colors,
         content = content
     )
+}
+
+object PorringTheme {
+    val colors: PorringColor
+        @Composable get() = LocalColor.current
 }

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Typography.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Typography.kt
@@ -1,0 +1,32 @@
+package com.kolown.porring.core.designsystem.ui.theme
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+object PorringTypography {
+    val Headline = TextStyle(
+        fontSize = 24.sp,
+        fontWeight = FontWeight.Bold
+    )
+    val Title = TextStyle(
+        fontSize = 18.sp,
+        fontWeight = FontWeight.SemiBold
+    )
+    val Body = TextStyle(
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Normal
+    )
+    val Caption = TextStyle(
+        fontSize = 10.sp,
+        fontWeight = FontWeight.Normal
+    )
+    val Label = TextStyle(
+        fontSize = 12.sp,
+        fontWeight = FontWeight.Medium
+    )
+    val SubLabel = TextStyle(
+        fontSize = 10.sp,
+        fontWeight = FontWeight.Medium
+    )
+}

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Typography.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Typography.kt
@@ -5,27 +5,27 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
 object PorringTypography {
-    val Headline = TextStyle(
+    val headline = TextStyle(
         fontSize = 24.sp,
         fontWeight = FontWeight.Bold
     )
-    val Title = TextStyle(
+    val title = TextStyle(
         fontSize = 18.sp,
         fontWeight = FontWeight.SemiBold
     )
-    val Body = TextStyle(
+    val body = TextStyle(
         fontSize = 14.sp,
         fontWeight = FontWeight.Normal
     )
-    val Caption = TextStyle(
+    val caption = TextStyle(
         fontSize = 10.sp,
         fontWeight = FontWeight.Normal
     )
-    val Label = TextStyle(
+    val label = TextStyle(
         fontSize = 12.sp,
         fontWeight = FontWeight.Medium
     )
-    val SubLabel = TextStyle(
+    val subLabel = TextStyle(
         fontSize = 10.sp,
         fontWeight = FontWeight.Medium
     )

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import com.kolown.porring.core.designsystem.ui.theme.PorringTheme
 import com.kolown.porring.core.navigation.MainMenuRoute
@@ -25,12 +26,13 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     private val mainViewModel: MainViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             val navigator: MainNavigator = rememberMainNavigator()
-            var isLightBars by remember { mutableStateOf(false) }
+            var isLightBars by rememberSaveable { mutableStateOf(false) }
 
             val currentRoute =
                 navigator.currentDestination?.route?.substringAfterLast(".").orEmpty()
@@ -53,7 +55,6 @@ class MainActivity : ComponentActivity() {
                     })
                 } else {
                     CompositionLocalProvider(LocalSnackBarBridge.provides(snackBarBridge)) {
-//                        AdminScreen()
                         MainScreen(
                             navigator = navigator,
                             mainViewModel

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainNavHost.kt
@@ -34,7 +34,7 @@ internal fun MainNavHost(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(PorringTheme.colors.Background)
+            .background(PorringTheme.colors.background)
     ) {
         NavHost(
             navController = navigator.navController,

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainNavHost.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.navigation.compose.NavHost
+import com.kolown.porring.core.designsystem.ui.theme.PorringTheme
 import com.kolown.porring.core.model.UploadModel
 import com.kolown.porring.core.navigation.MainMenuRoute
 import com.kolown.porring.feature.camera.navigation.cameraNavGraph
@@ -34,7 +34,7 @@ internal fun MainNavHost(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.White)
+            .background(PorringTheme.colors.Background)
     ) {
         NavHost(
             navController = navigator.navController,


### PR DESCRIPTION
## 📝작업 내용
-  Theme에 디자인 시스템 적용

### 작업 상세
- 기존 사용하던 MaterialTheme를 `Color`와 `Typography`를 적용한 *PorringTheme*로 변경.
- CompositionLocal을 통해 직접적인 접근 없이 `Theme`내부의 `object`를 통해 Color와 Typo를 사용할 수 있도록 구성.

## ✅ TODO
- 적용된 Theme를 사용해 화면별 color통일
- 컴포넌트 추가후 통일된 시스템으로 디자인 변경
- 시스템 바 색상 반영하도록 변경
- detail에서는 dark기반 색상만 반영하도록 `CompositionLocal`설정을 통해 color변경
