### PR TITLE
[Follow/PORRING-108] Follow UI 수정 및 firestore 연결

### DIFF
--- a/core/data-api/src/main/java/com/kolown/porring/core/data/api/datasource/local/LocalUserCacheDataSource.kt
+++ b/core/data-api/src/main/java/com/kolown/porring/core/data/api/datasource/local/LocalUserCacheDataSource.kt
@@ -13,6 +13,7 @@ interface LocalUserCacheDataSource {
 
     suspend fun insertFollows(follows: List<FollowData>)
     fun getFollowName(id: String): Flow<String?>
+    suspend fun updateFollowName(id: String, newName: String)
     fun getFollows(): PagingSource<Int, FollowData>
     suspend fun deleteFollow(id: String)
     suspend fun clearFollows()

--- a/core/data/src/main/java/com/kolown/porring/core/data/repository/FollowRepository.kt
+++ b/core/data/src/main/java/com/kolown/porring/core/data/repository/FollowRepository.kt
@@ -14,6 +14,7 @@ import com.kolown.porring.core.network.PostDataSource
 import com.kolown.porring.core.network.UserDataSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -22,10 +23,11 @@ import javax.inject.Named
 
 interface FollowRepository {
     suspend fun getFollowerName(followerId: String): Flow<String?>
-    suspend fun unFollowUser(followerId: String): Flow<Boolean>
+    suspend fun updateFollowerName(id: String, newName: String): Result<Unit>
+    suspend fun unFollowUser(id: String): Result<Unit>
     suspend fun fetchFollows()
     suspend fun clearFollowCache()
-    fun followUser(followerId: String, followerName: String): Flow<Boolean>
+    suspend fun followUser(id: String, name: String): Result<Unit>
     suspend fun getFollowsWithPaging(): Flow<PagingData<FollowWithThumbnail>>
 }
 
@@ -40,43 +42,57 @@ class FollowRepositoryImpl @Inject constructor(
         return localUserCacheDataSource.getFollowName(followerId)
     }
 
-    override fun followUser(
-        id: String,
-        name: String,
-    ): Flow<Boolean> = flow {
+    override suspend fun updateFollowerName(id: String, newName: String): Result<Unit> {
         val currentUserId = googleAuthDataSource.getUserId()
 
-        localUserCacheDataSource.insertFollows(
-            listOf(
-                FollowData(
-                    id = id,
-                    name = name
-                )
-            )
-        )
+        localUserCacheDataSource.updateFollowName(id, newName)
 
-        userDataSource.uploadFollow(
+        return userDataSource.uploadFollow(
             userId = currentUserId,
             follow = Follow(
                 id = id,
-                name = name
+                name = newName
             )
-        ).collect { success ->
-            emit(success)
+        )
+    }
+
+    override suspend fun followUser(
+        id: String,
+        name: String,
+    ): Result<Unit> {
+        return runCatching {
+            val currentUserId = googleAuthDataSource.getUserId()
+
+            localUserCacheDataSource.insertFollows(
+                listOf(
+                    FollowData(
+                        id = id,
+                        name = name
+                    )
+                )
+            )
+
+            userDataSource.uploadFollow(
+                userId = currentUserId,
+                follow = Follow(
+                    id = id,
+                    name = name
+                )
+            ).getOrThrow()
         }
     }
 
     override suspend fun unFollowUser(
         id: String,
-    ): Flow<Boolean> = flow {
-        val currentUserId = googleAuthDataSource.getUserId()
+    ): Result<Unit> {
+        return runCatching {
+            val currentUserId = googleAuthDataSource.getUserId()
 
-        localUserCacheDataSource.deleteFollow(id)
-        userDataSource.removeFollow(
-            userId = currentUserId,
-            followerId = id
-        ).collect { success ->
-            emit(success)
+            localUserCacheDataSource.deleteFollow(id)
+            userDataSource.removeFollow(
+                userId = currentUserId,
+                followerId = id
+            ).getOrThrow()
         }
     }
 

--- a/core/data/src/main/java/com/kolown/porring/core/data/repository/FollowRepository.kt
+++ b/core/data/src/main/java/com/kolown/porring/core/data/repository/FollowRepository.kt
@@ -59,8 +59,7 @@ class FollowRepositoryImpl @Inject constructor(
     override suspend fun followUser(
         id: String,
         name: String,
-    ): Result<Unit> {
-        return runCatching {
+    ): Result<Unit> = runCatching {
             val currentUserId = googleAuthDataSource.getUserId()
 
             localUserCacheDataSource.insertFollows(
@@ -78,23 +77,37 @@ class FollowRepositoryImpl @Inject constructor(
                     id = id,
                     name = name
                 )
-            ).getOrThrow()
-        }
-    }
+            )
+        }.fold(
+            onSuccess = {
+                it
+            },
+            onFailure = {
+                localUserCacheDataSource.deleteFollow(id)
+                throw it
+            }
+        )
+
 
     override suspend fun unFollowUser(
         id: String,
-    ): Result<Unit> {
-        return runCatching {
+    ): Result<Unit> = runCatching {
             val currentUserId = googleAuthDataSource.getUserId()
 
             localUserCacheDataSource.deleteFollow(id)
             userDataSource.removeFollow(
                 userId = currentUserId,
                 followerId = id
-            ).getOrThrow()
-        }
-    }
+            )
+        }.fold(
+            onSuccess = {
+                it
+            },
+            onFailure = {
+                throw it
+            }
+        )
+
 
     override suspend fun fetchFollows() = withContext(Dispatchers.IO) {
         val userId = googleAuthDataSource.getUserId()

--- a/core/local/src/main/java/com/kolown/porring/core/local/dao/FollowDao.kt
+++ b/core/local/src/main/java/com/kolown/porring/core/local/dao/FollowDao.kt
@@ -20,6 +20,9 @@ interface FollowDao {
     @Query("SELECT name FROM follow WHERE id = :id")
     fun getFollowName(id: String): Flow<String?>
 
+    @Query("UPDATE follow SET name = :newName WHERE id = :id")
+    suspend fun updateName(id: String, newName: String)
+
     @Query("DELETE FROM follow")
     suspend fun clearFollows()
 

--- a/core/local/src/main/java/com/kolown/porring/core/local/datasource/LocalUserCacheDataSourceImpl.kt
+++ b/core/local/src/main/java/com/kolown/porring/core/local/datasource/LocalUserCacheDataSourceImpl.kt
@@ -42,6 +42,10 @@ class LocalUserCacheDataSourceImpl @Inject constructor(
         return followDao.getFollowName(id)
     }
 
+    override suspend fun updateFollowName(id: String, newName: String) {
+        followDao.updateName(id, newName)
+    }
+
     override suspend fun deleteFollow(id: String) {
         followDao.deleteFollow(id)
     }

--- a/core/network/src/main/java/com/kolown/porring/core/network/UserDataSource.kt
+++ b/core/network/src/main/java/com/kolown/porring/core/network/UserDataSource.kt
@@ -1,5 +1,6 @@
 package com.kolown.porring.core.network
 
+import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
 import com.kolown.porring.core.data.dto.ReactedPostDto
 import com.kolown.porring.core.model.Follow
@@ -17,9 +18,9 @@ interface UserDataSource {
     suspend fun deleteReactedPost(userId: String, postId: String): Result<Unit>
     suspend fun fetchAllReactedPost(userId: String): List<ReactedPostDto>
 
-    suspend fun uploadFollow(userId: String, follow: Follow): Flow<Boolean>
+    suspend fun uploadFollow(userId: String, follow: Follow): Result<Unit>
     suspend fun fetchFollows(userId: String): List<Follow>
-    suspend fun removeFollow(userId: String, followerId: String): Flow<Boolean>
+    suspend fun removeFollow(userId: String, followerId: String): Result<Unit>
 }
 
 class UserDataSourceImpl @Inject constructor(
@@ -68,32 +69,31 @@ class UserDataSourceImpl @Inject constructor(
             .map { it.toObject(ReactedPostDto::class.java).copy(postId = it.id) }
     }
 
-    override suspend fun uploadFollow(userId: String, follow: Follow): Flow<Boolean> = flow {
-        userCollection
-            .document(userId)
-            .collection("followers")
-            .document(follow.id)
-            .set(mapOf("followerName" to follow.name))
-            .await()
-            .runCatching {
-                emit(true)
-            }.onFailure { _ ->
-                emit(false)
-            }
+    override suspend fun uploadFollow(userId: String, follow: Follow): Result<Unit> {
+        return runCatching {
+            userCollection
+                .document(userId)
+                .collection("followers")
+                .document(follow.id)
+                .set(mapOf("followerName" to follow.name))
+                .await()
+        }
     }
 
-    override suspend fun removeFollow(userId: String, followerId: String): Flow<Boolean> = flow {
-        val followersCollection = userCollection
-            .document(userId)
-            .collection("followers")
-        val followerDoc = followersCollection.document(followerId)
-        val docResult = followerDoc.get().await()
+    override suspend fun removeFollow(userId: String, followerId: String): Result<Unit> {
+        return runCatching {
+            val followerDoc = userCollection
+                .document(userId)
+                .collection("followers")
+                .document(followerId)
 
-        if (docResult.exists().not()) {
-            emit(false)
-        } else {
+            val docResult = followerDoc.get().await()
+
+            if(!docResult.exists()) {
+                throw IllegalStateException("팔로워 문서가 존재하지 않음")
+            }
+
             followerDoc.delete().await()
-            emit(true)
         }
     }
 

--- a/feature/detail/src/main/java/com/kolown/porring/feature/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/kolown/porring/feature/detail/DetailScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -129,7 +128,7 @@ internal fun DetailRoute(
                 description = "팔로우를 취소하시겠습니까?",
                 dismissText = "취소",
                 confirmText = "확인",
-                onConfirm = { viewModel.cancelFollow(post.authorId) },
+                onConfirm = { viewModel.unFollowUser(post.authorId) },
                 onDismissRequest = { followPostUiModel = null }
             )
         } else {

--- a/feature/detail/src/main/java/com/kolown/porring/feature/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/com/kolown/porring/feature/detail/DetailViewModel.kt
@@ -1,5 +1,6 @@
 package com.kolown.porring.feature.detail
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
@@ -22,7 +23,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -124,13 +124,17 @@ internal class DetailViewModel @Inject constructor(
         _followEvent.emit(postUiModel)
     }
 
-    fun cancelFollow(authorId: String) = viewModelScope.launch {
-        followRepository.unFollowUser(authorId).launchIn(viewModelScope)
+    fun unFollowUser(authorId: String) = viewModelScope.launch {
+        followRepository.unFollowUser(authorId)
+            .onFailure { Log.e("UnFollowUpload", "viewModel: $it") }
     }
 
     fun registerFollow(authorId: String, name: String) = viewModelScope.launch {
         if (checkedLogIn().not()) return@launch
 
-        followRepository.followUser(authorId, name).launchIn(viewModelScope)
+        followRepository.followUser(authorId, name)
+            .onFailure {
+                Log.e("Follow", "registerFollow: $it")
+            }
     }
 }

--- a/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowViewModel.kt
+++ b/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowViewModel.kt
@@ -1,5 +1,6 @@
 package com.kolown.porring.feature.follower
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
@@ -28,6 +29,22 @@ class FollowerViewModel @Inject constructor(
         viewModelScope.launch {
             followerRepository.getFollowsWithPaging()
                 .collectLatest(_followerItems::emit)
+        }
+    }
+
+    fun updateFollowerName(id: String, newName: String) {
+        viewModelScope.launch {
+            followerRepository.updateFollowerName(id, newName)
+                .onFailure {
+                    Log.e("Follow", "viewModel: $it")
+                }
+        }
+    }
+
+    fun unFollowUser(id: String) {
+        viewModelScope.launch {
+            followerRepository.unFollowUser(id)
+                .onFailure { Log.e("UnFollowUpload", "viewModel: $it") }
         }
     }
 }

--- a/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerContent.kt
+++ b/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerContent.kt
@@ -3,9 +3,7 @@ package com.kolown.porring.feature.follower
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,33 +12,28 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.kolown.porring.core.designsystem.ui.theme.Error
 import com.kolown.porring.core.designsystem.ui.theme.PorringTheme
 import com.kolown.porring.core.designsystem.ui.theme.PorringTypography
 import com.kolown.porring.core.designsystem.ui.theme.Primary
-import com.kolown.porring.core.designsystem.ui.theme.Surface
 import com.kolown.porring.core.model.FollowWithThumbnail
 import com.kolown.porring.core.ui.component.CoilImage
 
 @Composable
 internal fun FollowContent(
     followWithThumbnail: FollowWithThumbnail,
+    onClickUnfollow: (String) -> Unit = {},
     navigateToTheir: () -> Unit = {},
     updateFollowerThumbnail: (FollowWithThumbnail) -> Unit = {}
 ) {
@@ -110,6 +103,7 @@ internal fun FollowContent(
                     text = stringResource(R.string.string_un_follow),
                     color = PorringTheme.colors.error,
                     style = PorringTheme.typography.label,
+                    modifier = Modifier.clickable { onClickUnfollow(followWithThumbnail.id) }
                 )
             }
         }

--- a/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerContent.kt
+++ b/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerContent.kt
@@ -1,10 +1,12 @@
 package com.kolown.porring.feature.follower
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -19,6 +21,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -28,6 +31,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.kolown.porring.core.designsystem.ui.theme.Error
+import com.kolown.porring.core.designsystem.ui.theme.PorringTheme
+import com.kolown.porring.core.designsystem.ui.theme.PorringTypography
 import com.kolown.porring.core.designsystem.ui.theme.Primary
 import com.kolown.porring.core.designsystem.ui.theme.Surface
 import com.kolown.porring.core.model.FollowWithThumbnail
@@ -39,78 +44,75 @@ internal fun FollowContent(
     navigateToTheir: () -> Unit = {},
     updateFollowerThumbnail: (FollowWithThumbnail) -> Unit = {}
 ) {
-    val interactionSource = remember { MutableInteractionSource() }
-
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .wrapContentHeight()
-            .clickable(
-                interactionSource = interactionSource,
-                indication = null
-            ) {
-                navigateToTheir()
-            },
+            .background(PorringTheme.colors.surface)
+            .border(
+                width = 1.dp,
+                color = PorringTheme.colors.outlineVariant,
+                shape = RoundedCornerShape(10.dp)
+            )
+            .padding(16.dp)
+            .clickable(onClick = navigateToTheir),
         verticalArrangement = Arrangement.Center
     ) {
-        Spacer(modifier = Modifier.height(16.dp))
+        BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
+            val imageSize = (maxWidth - 16.dp) / 3
+
+            LazyRow(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(space = 8.dp)
+            ) {
+                items(followWithThumbnail.thumbnails) { imageUrl ->
+                    Card(
+                        modifier = Modifier
+                            .size(imageSize)
+                            .clip(RoundedCornerShape(10.dp)),
+                    ) {
+                        CoilImage(
+                            imageUrl = imageUrl,
+                            imageRatio = 1f,
+                            isClickedEnabled = false
+                        )
+                    }
+                }
+            }
+        }
+
+
+        Spacer(modifier = Modifier.height(12.dp))
 
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
+                .padding(bottom = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
                 text = followWithThumbnail.followerName,
                 color = Primary,
-                style = MaterialTheme.typography.titleLarge
+                style = PorringTypography.title
             )
-            Box(
-                modifier = Modifier.clickable { updateFollowerThumbnail(followWithThumbnail) }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 Text(
                     text = stringResource(R.string.string_edit),
-                    color = Error,
-                    style = MaterialTheme.typography.titleMedium,
+                    color = PorringTheme.colors.onSurface,
+                    style = PorringTheme.typography.label,
+                    modifier = Modifier.clickable { updateFollowerThumbnail(followWithThumbnail) }
+                )
+                Text(
+                    text = stringResource(R.string.string_un_follow),
+                    color = PorringTheme.colors.error,
+                    style = PorringTheme.typography.label,
                 )
             }
         }
-
-        Spacer(modifier = Modifier.height(10.dp))
-
-        LazyRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .align(Alignment.CenterHorizontally)
-                .padding(horizontal = 16.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(space = 8.dp)
-        ) {
-            items(followWithThumbnail.thumbnails) { imageUrl ->
-                Card(
-                    modifier = Modifier
-                        .size(100.dp)
-                        .clip(RoundedCornerShape(10.dp)),
-                ) {
-                    CoilImage(
-                        imageUrl = imageUrl,
-                        imageRatio = 1f,
-                        isClickedEnabled = false
-                    )
-                }
-            }
-        }
-
-        Spacer(modifier = Modifier.height(16.dp))
-
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(8.dp)
-                .background(Surface)
-        )
     }
 }
 

--- a/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerScreen.kt
+++ b/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerScreen.kt
@@ -35,6 +35,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.kolown.porring.core.designsystem.component.PorringCenterAlignTopAppBar
 import com.kolown.porring.core.designsystem.ui.theme.Background
 import com.kolown.porring.core.model.FollowWithThumbnail
+import com.kolown.porring.core.ui.component.BetaPorringAlertDialog
 import com.kolown.porring.core.ui.component.ErrorScreen
 import com.kolown.porring.core.ui.component.FollowDialog
 import com.kolown.porring.core.ui.component.LoadingScreen
@@ -56,6 +57,7 @@ internal fun FollowerRoute(
     val pagerState = rememberLazyListState()
 
     var followWithThumbnail by remember { mutableStateOf<FollowWithThumbnail?>(null) }
+    var unFollowTargetId by remember { mutableStateOf<String?>(null) }
     var showErrorScreen by remember { mutableStateOf(false) }
 
     var isRefreshing by remember { mutableStateOf(false) }
@@ -81,10 +83,29 @@ internal fun FollowerRoute(
         }
     }
 
-    followWithThumbnail?.let {
+    unFollowTargetId?.let { id ->
+        BetaPorringAlertDialog(
+            title = stringResource(R.string.string_unfollow),
+            description = stringResource(R.string.string_unfollow_description),
+            dismissText = stringResource(R.string.string_cancel),
+            confirmText = stringResource(R.string.string_confirm),
+            onConfirm = {
+                viewModel.unFollowUser(id)
+                unFollowTargetId = null
+            },
+            onDismissRequest = {
+                unFollowTargetId = null
+            }
+        )
+    }
+
+    followWithThumbnail?.let { followThumbnail ->
         FollowDialog(
             isAddFollow = false,
-            onClickConfirm = { },
+            onClickConfirm = { name ->
+                viewModel.updateFollowerName(followThumbnail.id, name)
+                followWithThumbnail = null
+            },
             onClickCancel = { followWithThumbnail = null }
         )
     }
@@ -99,6 +120,7 @@ internal fun FollowerRoute(
             refreshState = refreshState,
             onRefresh = onRefresh,
             scaleFraction = scaleFraction,
+            onClickUnfollow = { unFollowTargetId = it },
             navigateToTheir = navigateToTheir,
             updateFollowerThumbnail = { followWithThumbnail = it }
         )
@@ -120,6 +142,7 @@ private fun FollowerScreen(
     refreshState: PullToRefreshState = rememberPullToRefreshState(),
     onRefresh: () -> Unit = {},
     scaleFraction: () -> Float = { 1f },
+    onClickUnfollow: (String) -> Unit = {},
     navigateToTheir: (String) -> Unit = {},
     updateFollowerThumbnail: (FollowWithThumbnail) -> Unit = {}
 ) {
@@ -159,6 +182,7 @@ private fun FollowerScreen(
                         pagingItems[index]?.let {
                             FollowContent(
                                 followWithThumbnail = it,
+                                onClickUnfollow = onClickUnfollow,
                                 navigateToTheir = { navigateToTheir(it.id) },
                                 updateFollowerThumbnail = updateFollowerThumbnail
                             )

--- a/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerScreen.kt
+++ b/feature/follower/src/main/java/com/kolown/porring/feature/follower/FollowerScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -127,7 +129,7 @@ private fun FollowerScreen(
         isRefreshing = isRefreshing,
         onRefresh = onRefresh,
         scaleFraction = scaleFraction,
-        topBar = { PorringCenterAlignTopAppBar(title = stringResource(R.string.string_following)) }
+        topBar = { Spacer(modifier = Modifier.height(16.dp)) }
     ) {
         when {
             showErrorScreen -> {
@@ -150,7 +152,7 @@ private fun FollowerScreen(
                 LazyColumn(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(Background),
+                        .padding(horizontal = 12.dp),
                     state = pagerState,
                 ) {
                     items(pagingItems.itemCount) { index ->
@@ -160,6 +162,8 @@ private fun FollowerScreen(
                                 navigateToTheir = { navigateToTheir(it.id) },
                                 updateFollowerThumbnail = updateFollowerThumbnail
                             )
+
+                            Spacer(modifier = Modifier.height(8.dp))
                         }
                     }
 

--- a/feature/follower/src/main/res/values/strings.xml
+++ b/feature/follower/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="string_error">오류가 발생하였습니다!</string>
     <string name="string_retry">Retry</string>
     <string name="string_edit">수정</string>
+    <string name="string_un_follow">언팔로우</string>
 </resources>

--- a/feature/follower/src/main/res/values/strings.xml
+++ b/feature/follower/src/main/res/values/strings.xml
@@ -7,4 +7,8 @@
     <string name="string_retry">Retry</string>
     <string name="string_edit">수정</string>
     <string name="string_un_follow">언팔로우</string>
+    <string name="string_unfollow">팔로우 취소</string>
+    <string name="string_unfollow_description">팔로우를 취소하시겠습니까?</string>
+    <string name="string_cancel">취소</string>
+    <string name="string_confirm">확인</string>
 </resources>

--- a/feature/home/src/main/java/com/kolown/porring/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/kolown/porring/feature/home/HomeScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -118,7 +117,7 @@ internal fun HomeRoute(
                 description = stringResource(R.string.string_unfollow_description),
                 dismissText = stringResource(R.string.string_cancel),
                 confirmText = stringResource(R.string.string_confirm),
-                onConfirm = { viewModel.cancelFollow(post.authorId) },
+                onConfirm = { viewModel.unFollowUser(post.authorId) },
                 onDismissRequest = { followPostUiModel = null }
             )
         } else {

--- a/feature/home/src/main/java/com/kolown/porring/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/kolown/porring/feature/home/HomeViewModel.kt
@@ -1,5 +1,6 @@
 package com.kolown.porring.feature.home
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kolown.porring.core.data.repository.AuthRepository
@@ -19,7 +20,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -80,14 +80,18 @@ class HomeViewModel @Inject constructor(
         _followEvent.emit(postUiModel)
     }
 
-    fun cancelFollow(authorId: String) = viewModelScope.launch {
-        followRepository.unFollowUser(authorId).launchIn(viewModelScope)
+    fun unFollowUser(authorId: String) = viewModelScope.launch {
+        followRepository.unFollowUser(authorId)
+            .onFailure { Log.e("UnFollowUpload", "viewModel: $it") }
     }
 
     fun registerFollow(authorId: String, name: String) = viewModelScope.launch {
         if (checkedLogIn().not()) return@launch
 
-        followRepository.followUser(authorId, name).launchIn(viewModelScope)
+        followRepository.followUser(authorId, name)
+            .onFailure {
+                Log.e("Follow", "registerFollow: $it")
+            }
     }
 
     fun onReactionClick(postId: String, reaction: Reaction) = viewModelScope.launch {

--- a/feature/search/src/main/java/com/kolown/porring/feature/search/DetailSearchViewModel.kt
+++ b/feature/search/src/main/java/com/kolown/porring/feature/search/DetailSearchViewModel.kt
@@ -61,8 +61,10 @@ class DetailSearchViewModel @Inject constructor(
     fun followUser(id: String, name: String) {
         viewModelScope.launch {
             followRepository.followUser(id, name)
-                .catch { Log.e("FollowUpload", "viewModel: $it") }
-                .launchIn(viewModelScope)
+                .onFailure {
+                    Log.e("FollowUpload", "viewModel: $it")
+                }
+
             _followSharedFlow.emit(Pair(id, true))
         }
     }
@@ -70,8 +72,7 @@ class DetailSearchViewModel @Inject constructor(
     fun unFollowUser(id: String) {
         viewModelScope.launch {
             followRepository.unFollowUser(id)
-                .catch { Log.e("UnFollowUpload", "viewModel: $it") }
-                .launchIn(viewModelScope)
+                .onFailure { Log.e("UnFollowUpload", "viewModel: $it") }
             _followSharedFlow.emit(Pair(id, false))
         }
     }


### PR DESCRIPTION
## 📝작업 내용
- figma 기반으로 ui 수정
- 이유없이 쓰는 flow -> result로 변경
- follow 이름 수정 및 언팔로우 연결 

## 작업 상세
```kotlin
override suspend fun removeFollow(userId: String, followerId: String): Flow<Boolean> = flow {
    val followersCollection = userCollection
        .document(userId)
        .collection("followers")
    val followerDoc = followersCollection.document(followerId)
    val docResult = followerDoc.get().await()

    if (docResult.exists().not()) {
        emit(false)
    } else {
        followerDoc.delete().await()
        emit(true)
    }
}
```
하나의 데이터만 내리면 되는 부분이며, viewModel에서 그냥 launch만 하고 있는 부분들이 존재했음.
해당 부분들 Result로 결과를 받아서 실패했을때 viewModel에서 ui 상태 처리할 수 있도록 onFailure 분기 처리 해놓음


## 스크린샷

https://github.com/user-attachments/assets/9b633eb5-3564-4216-9cb3-e8eae5bb0658


## ✅ TODO
- 다이얼로그 UI 수정 필요
