### PR TITLE
navigation 정리

### DIFF
--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
@@ -21,7 +21,6 @@ import androidx.core.view.WindowCompat
 fun PorringTheme(
     content: @Composable () -> Unit,
 ) {
-    DarkThemeController.setDark(isSystemInDarkTheme())
     val isDark = DarkThemeController.isDark
     val colors = remember(isDark) { if (isDark) PorringDarkColor else PorringLightColor }
     val isLightSystemBars = !isDark

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
@@ -18,7 +18,7 @@ val LocalIsDarkTheme = staticCompositionLocalOf { false }
 
 @Composable
 fun PorringTheme(
-    isLightBars: Boolean,
+    isLightBars: Boolean = true,
     content: @Composable () -> Unit,
 ) {
     val isDark = LocalIsDarkTheme.current

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
@@ -6,43 +6,79 @@ import android.view.Window
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
-val LocalIsDarkTheme = staticCompositionLocalOf { false }
-
 @Composable
 fun PorringTheme(
-    isLightBars: Boolean = true,
     content: @Composable () -> Unit,
 ) {
-    val isDark = LocalIsDarkTheme.current
-    val colors: PorringColor = if (isDark) PorringDarkColor else PorringLightColor
+    val isDark = DarkThemeController.isDark
+    val colors = remember(isDark) { if (isDark) PorringDarkColor else PorringLightColor }
+    val isLightSystemBars = !isDark
 
     val view = LocalView.current
+    val window = (view.context as? Activity)?.window
+    val insetsController = window?.let { WindowCompat.getInsetsController(window, view) }
 
     SideEffect {
-        val window = (view.context as Activity).window
-        val insetsController = WindowCompat.getInsetsController(window, view)
-
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-        insetsController.isAppearanceLightStatusBars = isLightBars
-        insetsController.isAppearanceLightNavigationBars = isLightBars
-        window.statusBarColor = Color.Transparent.toArgb()
-        window.navigationBarColor = Color.Transparent.toArgb()
-//            if (isLightBars) Background.toArgb() else BackgroundDark.toArgb()
+        window?.let {
+            WindowCompat.setDecorFitsSystemWindows(window, false)
+            window.setSystemBarBackground()
+        }
     }
+
+    LaunchedEffect(isLightSystemBars) {
+        insetsController?.isAppearanceLightStatusBars = isLightSystemBars
+        insetsController?.isAppearanceLightNavigationBars = isLightSystemBars
+    }
+
 
     CompositionLocalProvider(
         LocalColor provides colors,
         LocalTypography provides PorringTypography,
         content = content
     )
+}
+
+@Composable
+fun DarkModeScreen(
+    content: @Composable () -> Unit
+) {
+    val previous = remember { DarkThemeController.isDark }
+
+    DisposableEffect(Unit) {
+        DarkThemeController.setDark(true)
+        onDispose { DarkThemeController.setDark(previous) }
+    }
+
+    content()
+}
+
+private object DarkThemeController {
+    private val _isDark = mutableStateOf(false)
+    val isDark: Boolean get() = _isDark.value
+
+    fun setDark(dark: Boolean) {
+        _isDark.value = dark
+    }
+}
+
+private fun Window.setSystemBarBackground() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        this.isNavigationBarContrastEnforced = false
+    }
+
+    this.statusBarColor = Color.Transparent.toArgb()
+    this.navigationBarColor = Color.Transparent.toArgb()
 }
 
 object PorringTheme {

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
@@ -21,6 +21,7 @@ import androidx.core.view.WindowCompat
 fun PorringTheme(
     content: @Composable () -> Unit,
 ) {
+    DarkThemeController.setDark(isSystemInDarkTheme())
     val isDark = DarkThemeController.isDark
     val colors = remember(isDark) { if (isDark) PorringDarkColor else PorringLightColor }
     val isLightSystemBars = !isDark

--- a/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/kolown/porring/core/designsystem/ui/theme/Theme.kt
@@ -8,36 +8,34 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
+val LocalIsDarkTheme = staticCompositionLocalOf { false }
+
 @Composable
 fun PorringTheme(
-    currentRoute: String = "",
+    isLightBars: Boolean,
     content: @Composable () -> Unit,
 ) {
-    val isForcedDarkMode = currentRoute.shouldForceDarkMode()
-    val isDarkMode = if (isForcedDarkMode) true else isSystemInDarkTheme()
-
-    val colors: PorringColor = if (isDarkMode) PorringDarkColor else PorringLightColor
-    val isLightSystemBars = isDarkMode.not()
+    val isDark = LocalIsDarkTheme.current
+    val colors: PorringColor = if (isDark) PorringDarkColor else PorringLightColor
 
     val view = LocalView.current
-    val window = (view.context as? Activity)?.window
-    val insetsController = window?.let { WindowCompat.getInsetsController(window, view) }
 
     SideEffect {
-        window?.let {
-            WindowCompat.setDecorFitsSystemWindows(window, false)
-            window.setSystemBarBackground()
-        }
-    }
+        val window = (view.context as Activity).window
+        val insetsController = WindowCompat.getInsetsController(window, view)
 
-    LaunchedEffect(isLightSystemBars) {
-        insetsController?.isAppearanceLightStatusBars = isLightSystemBars
-        insetsController?.isAppearanceLightNavigationBars = isLightSystemBars
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+        insetsController.isAppearanceLightStatusBars = isLightBars
+        insetsController.isAppearanceLightNavigationBars = isLightBars
+        window.statusBarColor = Color.Transparent.toArgb()
+        window.navigationBarColor = Color.Transparent.toArgb()
+//            if (isLightBars) Background.toArgb() else BackgroundDark.toArgb()
     }
 
     CompositionLocalProvider(
@@ -45,23 +43,6 @@ fun PorringTheme(
         LocalTypography provides PorringTypography,
         content = content
     )
-}
-
-private fun Window.setSystemBarBackground() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-        this.isNavigationBarContrastEnforced = false
-    }
-
-    this.statusBarColor = Color.Transparent.toArgb()
-    this.navigationBarColor = Color.Transparent.toArgb()
-}
-
-private fun String.shouldForceDarkMode(): Boolean {
-    return when {
-        this.startsWith("Detail") -> true
-        this.startsWith("Camera") -> true
-        else -> false
-    }
 }
 
 object PorringTheme {

--- a/core/navigation/src/main/java/com/kolown/porring/core/navigation/CameraRoute.kt
+++ b/core/navigation/src/main/java/com/kolown/porring/core/navigation/CameraRoute.kt
@@ -1,0 +1,16 @@
+package com.kolown.porring.core.navigation
+
+import com.kolown.porring.core.model.UploadModel
+import kotlinx.serialization.Serializable
+
+sealed interface CameraRoute: Route {
+
+    @Serializable
+    data object Camera : CameraRoute
+
+    @Serializable
+    data class ImageEdit(val imgUri: String) : CameraRoute
+
+    @Serializable
+    data class Upload(val imgUri: String, val imageRatio: Float, val uploadModel: UploadModel) : CameraRoute
+}

--- a/core/navigation/src/main/java/com/kolown/porring/core/navigation/MainMenuRoute.kt
+++ b/core/navigation/src/main/java/com/kolown/porring/core/navigation/MainMenuRoute.kt
@@ -1,0 +1,35 @@
+package com.kolown.porring.core.navigation
+
+import kotlinx.serialization.Serializable
+
+sealed interface MainMenuRoute : Route {
+
+    @Serializable
+    data object Home : MainMenuRoute
+
+    @Serializable
+    data object Search : MainMenuRoute
+
+    @Serializable
+    data object Follower : MainMenuRoute
+
+    @Serializable
+    data object My : MainMenuRoute
+
+}
+
+sealed interface HomeRoute : MainMenuRoute {
+    @Serializable
+    data object Home : HomeRoute
+
+    @Serializable
+    data class HomeGallery(val authorId: String) : HomeRoute
+}
+
+sealed interface FollowRoute : MainMenuRoute {
+    @Serializable
+    data object Follow : FollowRoute
+
+    @Serializable
+    data class FollowGallery(val authorId: String) : FollowRoute
+}

--- a/core/navigation/src/main/java/com/kolown/porring/core/navigation/OnBoardRoute.kt
+++ b/core/navigation/src/main/java/com/kolown/porring/core/navigation/OnBoardRoute.kt
@@ -1,0 +1,12 @@
+package com.kolown.porring.core.navigation
+
+import kotlinx.serialization.Serializable
+
+sealed interface OnBoardRoute: Route {
+    
+    @Serializable
+    data object Login : OnBoardRoute
+
+    @Serializable
+    data object Join : OnBoardRoute
+}

--- a/core/navigation/src/main/java/com/kolown/porring/core/navigation/RouteModel.kt
+++ b/core/navigation/src/main/java/com/kolown/porring/core/navigation/RouteModel.kt
@@ -1,33 +1,13 @@
 package com.kolown.porring.core.navigation
 
-import com.kolown.porring.core.model.UploadModel
 import kotlinx.serialization.Serializable
 
 sealed interface Route {
     @Serializable
-    data class ImageEdit(val imgUri: String) : Route
-
-    @Serializable
-    data class Upload(val imgUri: String, val imageRatio: Float, val uploadModel: UploadModel) :
-        Route
-
-    @Serializable
-    data object Login : Route
-
-    @Serializable
     data object Setting : Route
 
     @Serializable
-    data object Join : Route
-
-    @Serializable
     data object DetailSearch : Route
-
-    @Serializable
-    data class DetailMy(val pageIndex: Int) : Route
-
-    @Serializable
-    data object DetailTheir : Route
 
     @Serializable
     data object DeletedAccount : Route
@@ -37,26 +17,9 @@ sealed interface Route {
 
     @Serializable
     data object UserInfo : Route
-}
-
-sealed interface MainMenuRoute : Route {
-    @Serializable
-    data object Home : MainMenuRoute
 
     @Serializable
-    data object Search : MainMenuRoute
-
-    @Serializable
-    data object Camera : MainMenuRoute
-
-    @Serializable
-    data object Follower : MainMenuRoute
-
-    @Serializable
-    data object My : MainMenuRoute
-
-    @Serializable
-    data class Their(val authorId: String) : MainMenuRoute
+    data class Their(val authorId: String) : Route
 
     @Serializable
     data class Detail(
@@ -64,11 +27,13 @@ sealed interface MainMenuRoute : Route {
         val order: Int,
         val authorId: String,
         val postId: String? = null,
-    ) :
-        MainMenuRoute {
+    ) : Route {
         @Serializable
         enum class Type {
             DEFAULT, MY, FOLLOW, SEARCH
         }
     }
+
+    @Serializable
+    data class DetailMy(val pageIndex: Int) : Route
 }

--- a/core/navigation/src/main/java/com/kolown/porring/core/navigation/util.kt
+++ b/core/navigation/src/main/java/com/kolown/porring/core/navigation/util.kt
@@ -1,0 +1,28 @@
+package com.kolown.porring.core.navigation
+
+import kotlin.reflect.KClass
+
+fun String.toRouteClassOrNull(): KClass<out Route>? =
+    when(this) {
+        Route.Setting::class.qualifiedName -> Route.Setting::class
+        Route.DetailSearch::class.qualifiedName -> Route.DetailSearch::class
+        Route.DeletedAccount::class.qualifiedName -> Route.DeletedAccount::class
+        Route.Privacy::class.qualifiedName -> Route.Privacy::class
+        Route.UserInfo::class.qualifiedName -> Route.UserInfo::class
+        Route.Their::class.qualifiedName -> Route.Their::class
+        Route.DetailMy::class.qualifiedName -> Route.DetailMy::class
+
+        MainMenuRoute.Home::class.qualifiedName -> MainMenuRoute.Home::class
+        MainMenuRoute.Search::class.qualifiedName -> MainMenuRoute.Search::class
+        MainMenuRoute.Follower::class.qualifiedName -> MainMenuRoute.Follower::class
+        MainMenuRoute.My::class.qualifiedName -> MainMenuRoute.My::class
+
+        OnBoardRoute.Login::class.qualifiedName -> OnBoardRoute.Login::class
+        OnBoardRoute.Join::class.qualifiedName -> OnBoardRoute.Join::class
+
+        CameraRoute.Camera::class.qualifiedName -> CameraRoute.Camera::class
+        CameraRoute.ImageEdit::class.qualifiedName -> CameraRoute.ImageEdit::class
+        CameraRoute.Upload::class.qualifiedName -> CameraRoute.Upload::class
+
+        else -> null
+    }

--- a/feature/camera/src/main/java/com/kolown/porring/feature/camera/navigation/CameraNavigation.kt
+++ b/feature/camera/src/main/java/com/kolown/porring/feature/camera/navigation/CameraNavigation.kt
@@ -4,18 +4,18 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.kolown.porring.core.navigation.MainMenuRoute
+import com.kolown.porring.core.navigation.CameraRoute
 import com.kolown.porring.feature.camera.screen.CameraRoute
 
 fun NavController.navigateCamera(navOptions: NavOptions) {
-    navigate(MainMenuRoute.Camera, navOptions)
+    navigate(CameraRoute.Camera, navOptions)
 }
 
 fun NavGraphBuilder.cameraNavGraph(
     navigateToImageEdit: (String) -> Unit = {},
     popBackStack: () -> Unit = {}
 ) {
-    composable<MainMenuRoute.Camera> {
+    composable<CameraRoute.Camera> {
         CameraRoute(
             navigateToImageEdit = navigateToImageEdit,
             popBackStack = popBackStack

--- a/feature/camera/src/main/java/com/kolown/porring/feature/camera/screen/CameraScreen.kt
+++ b/feature/camera/src/main/java/com/kolown/porring/feature/camera/screen/CameraScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -15,6 +16,8 @@ import androidx.compose.ui.res.vectorResource
 import com.kolown.porring.core.designsystem.R.drawable
 import com.kolown.porring.core.designsystem.component.PorringIconButton
 import com.kolown.porring.core.designsystem.component.PorringTopAppBar
+import com.kolown.porring.core.designsystem.ui.theme.LocalIsDarkTheme
+import com.kolown.porring.core.designsystem.ui.theme.PorringTheme
 import com.kolown.porring.feature.camera.R
 
 
@@ -23,10 +26,14 @@ internal fun CameraRoute(
     navigateToImageEdit: (String) -> Unit = {},
     popBackStack: () -> Unit = {},
 ) {
-    CameraScreen(
-        navigateToImageEdit = navigateToImageEdit,
-        popBackStack = popBackStack,
-    )
+    CompositionLocalProvider(
+        LocalIsDarkTheme provides true
+    ) {
+        CameraScreen(
+            navigateToImageEdit = navigateToImageEdit,
+            popBackStack = popBackStack,
+        )
+    }
 }
 
 @Composable

--- a/feature/camera/src/main/java/com/kolown/porring/feature/camera/screen/CameraScreen.kt
+++ b/feature/camera/src/main/java/com/kolown/porring/feature/camera/screen/CameraScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -16,8 +15,7 @@ import androidx.compose.ui.res.vectorResource
 import com.kolown.porring.core.designsystem.R.drawable
 import com.kolown.porring.core.designsystem.component.PorringIconButton
 import com.kolown.porring.core.designsystem.component.PorringTopAppBar
-import com.kolown.porring.core.designsystem.ui.theme.LocalIsDarkTheme
-import com.kolown.porring.core.designsystem.ui.theme.PorringTheme
+import com.kolown.porring.core.designsystem.ui.theme.DarkModeScreen
 import com.kolown.porring.feature.camera.R
 
 
@@ -26,9 +24,7 @@ internal fun CameraRoute(
     navigateToImageEdit: (String) -> Unit = {},
     popBackStack: () -> Unit = {},
 ) {
-    CompositionLocalProvider(
-        LocalIsDarkTheme provides true
-    ) {
+    DarkModeScreen {
         CameraScreen(
             navigateToImageEdit = navigateToImageEdit,
             popBackStack = popBackStack,

--- a/feature/detail-my/src/main/java/com/kolown/porring/feature/detail_my/DetailMyScreen.kt
+++ b/feature/detail-my/src/main/java/com/kolown/porring/feature/detail_my/DetailMyScreen.kt
@@ -31,6 +31,7 @@ import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.kolown.porring.core.designsystem.component.PorringIconButton
 import com.kolown.porring.core.designsystem.component.PorringTopAppBar
+import com.kolown.porring.core.designsystem.ui.theme.DarkModeScreen
 import com.kolown.porring.core.model.MyPost
 import com.kolown.porring.core.ui.component.CoilImage
 import com.kolown.porring.core.ui.component.FullscreenImageViewer
@@ -47,19 +48,21 @@ internal fun DetailMyRoute(
         pageCount = { pagingItems.itemCount }
     )
 
-    if (uiState.isFocusMode) {
-        FullscreenImageViewer(
-            imageUrl = uiState.focusImageUrl,
-            imageRatio = uiState.focusImageRatio,
-            onDismiss = { viewModel.onAction(DetailMyIntent.ChangeToDefaultMode) }
-        )
-    } else {
-        DetailMyScreen(
-            pagerState = pagerState,
-            popBackStack = popBackStack,
-            pagingItems = pagingItems,
-            onAction = viewModel::onAction,
-        )
+    DarkModeScreen {
+        if (uiState.isFocusMode) {
+            FullscreenImageViewer(
+                imageUrl = uiState.focusImageUrl,
+                imageRatio = uiState.focusImageRatio,
+                onDismiss = { viewModel.onAction(DetailMyIntent.ChangeToDefaultMode) }
+            )
+        } else {
+            DetailMyScreen(
+                pagerState = pagerState,
+                popBackStack = popBackStack,
+                pagingItems = pagingItems,
+                onAction = viewModel::onAction,
+            )
+        }
     }
 }
 

--- a/feature/detail/src/main/java/com/kolown/porring/feature/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/kolown/porring/feature/detail/DetailScreen.kt
@@ -47,6 +47,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import com.kolown.porring.core.designsystem.component.PorringIconButton
 import com.kolown.porring.core.designsystem.component.PorringTopAppBar
 import com.kolown.porring.core.designsystem.ui.theme.Background
+import com.kolown.porring.core.designsystem.ui.theme.DarkModeScreen
 import com.kolown.porring.core.designsystem.ui.theme.Primary
 import com.kolown.porring.core.designsystem.ui.theme.PrimaryDark
 import com.kolown.porring.core.model.PageState
@@ -144,28 +145,30 @@ internal fun DetailRoute(
         }
     }
 
-    if (reelsModePostUrl != null) {
-        val currentPost = posts[pagerState.currentPage]
+    DarkModeScreen {
+        if (reelsModePostUrl != null) {
+            val currentPost = posts[pagerState.currentPage]
 
-        FullScreenEffect()
-        BackHandler(onBack = { reelsModePostUrl = null })
-        FocusScreen(
-            postUrl = reelsModePostUrl ?: "",
-            imageRatio = currentPost?.imageRatio ?: (4f / 5f),
-            onDismiss = { reelsModePostUrl = null }
-        )
-    } else {
-        DetailScreen(
-            posts = posts,
-            pagerState = pagerState,
-            eventRowVisible = type != Route.Detail.Type.MY,
-            galleryVisible = type == Route.Detail.Type.DEFAULT,
-            onShowReelsMode = { reelsModePostUrl = it },
-            onReactionClick = viewModel::onReactionClick,
-            onGalleryClick = navigateToTheir,
-            onFollowClick = viewModel::onFollowClick,
-            popBackStack = popBackStack
-        )
+            FullScreenEffect()
+            BackHandler(onBack = { reelsModePostUrl = null })
+            FocusScreen(
+                postUrl = reelsModePostUrl ?: "",
+                imageRatio = currentPost?.imageRatio ?: (4f / 5f),
+                onDismiss = { reelsModePostUrl = null }
+            )
+        } else {
+            DetailScreen(
+                posts = posts,
+                pagerState = pagerState,
+                eventRowVisible = type != Route.Detail.Type.MY,
+                galleryVisible = type == Route.Detail.Type.DEFAULT,
+                onShowReelsMode = { reelsModePostUrl = it },
+                onReactionClick = viewModel::onReactionClick,
+                onGalleryClick = navigateToTheir,
+                onFollowClick = viewModel::onFollowClick,
+                popBackStack = popBackStack
+            )
+        }
     }
 }
 

--- a/feature/detail/src/main/java/com/kolown/porring/feature/detail/DetailScreen.kt
+++ b/feature/detail/src/main/java/com/kolown/porring/feature/detail/DetailScreen.kt
@@ -52,7 +52,7 @@ import com.kolown.porring.core.designsystem.ui.theme.PrimaryDark
 import com.kolown.porring.core.model.PageState
 import com.kolown.porring.core.model.Reaction
 import com.kolown.porring.core.model.SnackBarEvent
-import com.kolown.porring.core.navigation.MainMenuRoute
+import com.kolown.porring.core.navigation.Route
 import com.kolown.porring.core.ui.component.BetaPorringAlertDialog
 import com.kolown.porring.core.ui.component.CoilImage
 import com.kolown.porring.core.ui.component.FollowDialog
@@ -67,7 +67,7 @@ import kotlinx.coroutines.flow.first
 
 @Composable
 internal fun DetailRoute(
-    type: MainMenuRoute.Detail.Type,
+    type: Route.Detail.Type,
     order: Int,
     authorId: String,
     postId: String?,
@@ -158,8 +158,8 @@ internal fun DetailRoute(
         DetailScreen(
             posts = posts,
             pagerState = pagerState,
-            eventRowVisible = type != MainMenuRoute.Detail.Type.MY,
-            galleryVisible = type == MainMenuRoute.Detail.Type.DEFAULT,
+            eventRowVisible = type != Route.Detail.Type.MY,
+            galleryVisible = type == Route.Detail.Type.DEFAULT,
             onShowReelsMode = { reelsModePostUrl = it },
             onReactionClick = viewModel::onReactionClick,
             onGalleryClick = navigateToTheir,

--- a/feature/detail/src/main/java/com/kolown/porring/feature/detail/DetailViewModel.kt
+++ b/feature/detail/src/main/java/com/kolown/porring/feature/detail/DetailViewModel.kt
@@ -12,7 +12,7 @@ import com.kolown.porring.core.data.repository.PostRepository
 import com.kolown.porring.core.data.repository.PostType
 import com.kolown.porring.core.model.PageState
 import com.kolown.porring.core.model.Reaction
-import com.kolown.porring.core.navigation.MainMenuRoute
+import com.kolown.porring.core.navigation.Route
 import com.kolown.porring.core.ui.mapper.toUiModel
 import com.kolown.porring.core.ui.model.PostUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -57,12 +57,12 @@ internal class DetailViewModel @Inject constructor(
         )
 
     fun initViewModel(
-        type: MainMenuRoute.Detail.Type,
+        type: Route.Detail.Type,
         postId: String?,
         authorId: String,
     ) = viewModelScope.launch {
         when (type) {
-            MainMenuRoute.Detail.Type.DEFAULT -> {
+            Route.Detail.Type.DEFAULT -> {
                 postRepository.getPagingItemPosts(
                     postType = PostType.RANDOM_DETAIL,
                     pageState = pageState,
@@ -70,13 +70,13 @@ internal class DetailViewModel @Inject constructor(
                     .collectLatest(_posts::emit)
             }
 
-            MainMenuRoute.Detail.Type.SEARCH -> {
+            Route.Detail.Type.SEARCH -> {
                 postRepository.getPostBySearch(authorId)
                     .map { pagingData -> pagingData.map { it.toUiModel() } }
                     .collectLatest(_posts::emit)
             }
 
-            MainMenuRoute.Detail.Type.FOLLOW -> {
+            Route.Detail.Type.FOLLOW -> {
                 postRepository.getPagingItemPosts(
                     postType = PostType.USER_DETAIL,
                     pageState = pageState,
@@ -88,7 +88,7 @@ internal class DetailViewModel @Inject constructor(
             }
 
 
-            MainMenuRoute.Detail.Type.MY -> {
+            Route.Detail.Type.MY -> {
                 postRepository.getPagingItemPosts(
                     postType = PostType.USER_DETAIL,
                     pageState = pageState,

--- a/feature/detail/src/main/java/com/kolown/porring/feature/detail/navigation/DetailNavigaition.kt
+++ b/feature/detail/src/main/java/com/kolown/porring/feature/detail/navigation/DetailNavigaition.kt
@@ -5,29 +5,29 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.kolown.porring.core.navigation.MainMenuRoute
+import com.kolown.porring.core.navigation.Route
 import com.kolown.porring.feature.detail.DetailRoute
 
 fun NavController.navigateToDetail(
-    type: MainMenuRoute.Detail.Type,
+    type: Route.Detail.Type,
     order: Int,
     navOptions: NavOptions,
     authorId: String = "",
     postId: String? = null
 ) {
-    navigate(MainMenuRoute.Detail(type, order, authorId, postId), navOptions = navOptions)
+    navigate(Route.Detail(type, order, authorId, postId), navOptions = navOptions)
 }
 
 fun NavGraphBuilder.detailNavGraph(
     popBackStack: () -> Unit,
     navigateToTheir: (String) -> Unit,
 ) {
-    composable<MainMenuRoute.Detail> {
+    composable<Route.Detail> {
         DetailRoute(
-            type = it.toRoute<MainMenuRoute.Detail>().type,
-            order = it.toRoute<MainMenuRoute.Detail>().order,
-            authorId = it.toRoute<MainMenuRoute.Detail>().authorId,
-            postId = it.toRoute<MainMenuRoute.Detail>().postId,
+            type = it.toRoute<Route.Detail>().type,
+            order = it.toRoute<Route.Detail>().order,
+            authorId = it.toRoute<Route.Detail>().authorId,
+            postId = it.toRoute<Route.Detail>().postId,
             navigateToTheir = navigateToTheir,
             popBackStack = popBackStack,
         )

--- a/feature/follower/build.gradle.kts
+++ b/feature/follower/build.gradle.kts
@@ -14,4 +14,6 @@ dependencies {
     //paging
     implementation(libs.androidx.paging.runtime)
     implementation(libs.androidx.paging.compose)
+
+    implementation(projects.feature.their)
 }

--- a/feature/follower/src/main/java/com/kolown/porring/feature/follower/navigation/FollowerNavigation.kt
+++ b/feature/follower/src/main/java/com/kolown/porring/feature/follower/navigation/FollowerNavigation.kt
@@ -1,24 +1,44 @@
 package com.kolown.porring.feature.follower.navigation
 
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import com.kolown.porring.core.navigation.FollowRoute
 import com.kolown.porring.core.navigation.MainMenuRoute
+import com.kolown.porring.feature.follower.FollowerRoute
+import com.kolown.porring.feature.their.TheirRoute
 import com.kolown.porring.feature.follower.FollowerRoute
 
 fun NavController.navigateFollower(navOptions: NavOptions) {
     navigate(MainMenuRoute.Follower, navOptions)
 }
 
+fun NavController.navigateFollowerGallery(authorId: String, navOptions: NavOptions? = null) {
+    navigate(FollowRoute.FollowGallery(authorId), navOptions)
+}
+
 fun NavGraphBuilder.followerNavGraph(
     navigateToLogin: () -> Unit,
     navigateToTheir: (String) -> Unit,
+    navigateToDetail: (String, String) -> Unit,
+    popBackStack: () -> Unit
 ) {
-    composable<MainMenuRoute.Follower> {
-        FollowerRoute(
-            navigateToLogin = navigateToLogin,
-            navigateToTheir = navigateToTheir
-        )
+    navigation<MainMenuRoute.Follower>(FollowRoute.Follow) {
+        composable<FollowRoute.Follow> {
+            FollowerRoute(
+                navigateToLogin = navigateToLogin,
+                navigateToTheir = navigateToTheir
+            )
+        }
+
+        composable<FollowRoute.FollowGallery> {
+            TheirRoute(
+                navigateToDetail = navigateToDetail,
+                popBackStack = popBackStack
+            )
+        }
     }
 }

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -13,4 +13,6 @@ dependencies {
 
     //lottie
     implementation(libs.lottie.compose)
+
+    implementation(projects.feature.their)
 }

--- a/feature/home/src/main/java/com/kolown/porring/feature/home/navigation/HomeNavigation.kt
+++ b/feature/home/src/main/java/com/kolown/porring/feature/home/navigation/HomeNavigation.kt
@@ -4,21 +4,39 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.navigation
+import com.kolown.porring.core.navigation.HomeRoute
 import com.kolown.porring.core.navigation.MainMenuRoute
 import com.kolown.porring.feature.home.HomeRoute
+import com.kolown.porring.feature.their.TheirRoute
 
 fun NavController.navigateHome(navOptions: NavOptions) {
     navigate(MainMenuRoute.Home, navOptions)
 }
 
+fun NavController.navigateHomeGallery(authorId: String, navOptions: NavOptions? = null) {
+    navigate(HomeRoute.HomeGallery(authorId), navOptions)
+}
+
 fun NavGraphBuilder.homeNavGraph(
     navigateToTheir: (String) -> Unit,
     navigateToDetail: () -> Unit,
+    navigateToGalleryDetail: (String, String) -> Unit,
+    popBackStack: () -> Unit
 ) {
-    composable<MainMenuRoute.Home> {
-        HomeRoute(
-            navigateToDetail = navigateToDetail,
-            navigateToTheir = navigateToTheir,
-        )
+    navigation<MainMenuRoute.Home>(HomeRoute.Home) {
+        composable<HomeRoute.Home> {
+            HomeRoute(
+                navigateToDetail = navigateToDetail,
+                navigateToTheir = navigateToTheir,
+            )
+        }
+
+        composable<HomeRoute.HomeGallery> {
+            TheirRoute(
+                navigateToDetail = navigateToGalleryDetail,
+                popBackStack = popBackStack
+            )
+        }
     }
 }

--- a/feature/image-edit/src/main/java/com/kolown/porring/feature/imageedit/navigation/ImageEditNavigation.kt
+++ b/feature/image-edit/src/main/java/com/kolown/porring/feature/imageedit/navigation/ImageEditNavigation.kt
@@ -5,19 +5,19 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
-import com.kolown.porring.core.navigation.Route
+import com.kolown.porring.core.navigation.CameraRoute
 import com.kolown.porring.feature.imageedit.ImageEditRoute
 
 fun NavController.navigateImageEdit(imgUri: String, navOptions: NavOptions? = null) {
-    navigate(Route.ImageEdit(imgUri), navOptions)
+    navigate(CameraRoute.ImageEdit(imgUri), navOptions)
 }
 
 fun NavGraphBuilder.imageEditNavGraph(
     navigateToHome: () -> Unit,
     navigateToUpload: (String, Float) -> Unit
 ) {
-    composable<Route.ImageEdit> { navBackStackEntry ->
-        val imgUri = navBackStackEntry.toRoute<Route.ImageEdit>().imgUri
+    composable<CameraRoute.ImageEdit> { navBackStackEntry ->
+        val imgUri = navBackStackEntry.toRoute<CameraRoute.ImageEdit>().imgUri
 
         ImageEditRoute(
             imgUri = imgUri,

--- a/feature/join/src/main/java/com/kolown/porring/feature/join/JoinScreen.kt
+++ b/feature/join/src/main/java/com/kolown/porring/feature/join/JoinScreen.kt
@@ -55,7 +55,6 @@ import com.kolown.porring.core.designsystem.ui.theme.PrimaryUnActive
 import com.kolown.porring.core.model.UiState
 import com.kolown.porring.core.navigation.OnBoardRoute
 import com.kolown.porring.core.navigation.Route
-import com.kolown.porring.core.ui.component.LocalSnackBarBridge
 import com.kolown.porring.core.ui.compositionlocal.LocalPaddingValues
 import com.kolown.porring.core.ui.compositionlocal.LocalSnackBarBridge
 

--- a/feature/join/src/main/java/com/kolown/porring/feature/join/JoinScreen.kt
+++ b/feature/join/src/main/java/com/kolown/porring/feature/join/JoinScreen.kt
@@ -31,6 +31,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.FocusRequester.Companion.FocusRequesterFactory.component1
+import androidx.compose.ui.focus.FocusRequester.Companion.FocusRequesterFactory.component2
+import androidx.compose.ui.focus.FocusRequester.Companion.FocusRequesterFactory.component3
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -50,7 +53,9 @@ import com.kolown.porring.core.designsystem.ui.theme.Error
 import com.kolown.porring.core.designsystem.ui.theme.Primary
 import com.kolown.porring.core.designsystem.ui.theme.PrimaryUnActive
 import com.kolown.porring.core.model.UiState
+import com.kolown.porring.core.navigation.OnBoardRoute
 import com.kolown.porring.core.navigation.Route
+import com.kolown.porring.core.ui.component.LocalSnackBarBridge
 import com.kolown.porring.core.ui.compositionlocal.LocalPaddingValues
 import com.kolown.porring.core.ui.compositionlocal.LocalSnackBarBridge
 
@@ -73,7 +78,7 @@ internal fun JoinRoute(
 
             is UiState.Success -> {
                 snackBarBridge.postSnackBarString(context.getString(R.string.string_complete_signup))
-                popBackStack(Route.Login)
+                popBackStack(OnBoardRoute.Login)
             }
 
             is UiState.Loading -> {
@@ -99,7 +104,7 @@ internal fun JoinRoute(
             }
         }
         if (joinState is UiState.Success) {
-            popBackStack(Route.Login)
+            popBackStack(OnBoardRoute.Login)
         }
     }
 
@@ -131,7 +136,7 @@ private fun JoinScreen(
             trailingIcon = {
                 PorringIconButton(
                     icon = Icons.Default.Close,
-                    onClick = { popBackStack(Route.Login) },
+                    onClick = { popBackStack(OnBoardRoute.Login) },
                     contentDescription = stringResource(R.string.string_go_back)
                 )
             }

--- a/feature/join/src/main/java/com/kolown/porring/feature/join/navigation/JoinNavigation.kt
+++ b/feature/join/src/main/java/com/kolown/porring/feature/join/navigation/JoinNavigation.kt
@@ -5,17 +5,18 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.kolown.porring.feature.join.JoinRoute
+import com.kolown.porring.core.navigation.OnBoardRoute
 import com.kolown.porring.core.navigation.Route
+import com.kolown.porring.feature.join.JoinRoute
 
 fun NavController.navigateToJoin(navOptions: NavOptions) {
-    navigate(Route.Join, navOptions = navOptions)
+    navigate(OnBoardRoute.Join, navOptions = navOptions)
 }
 
 fun NavGraphBuilder.joinNavGraph(
     popBackStack: (Route) -> Unit,
 ) {
-    composable<Route.Join> {
+    composable<OnBoardRoute.Join> {
         JoinRoute(
             popBackStack = popBackStack,
         )

--- a/feature/login/src/main/java/com/kolown/porring/feature/login/navigation/LoginNavigation.kt
+++ b/feature/login/src/main/java/com/kolown/porring/feature/login/navigation/LoginNavigation.kt
@@ -5,18 +5,18 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.kolown.porring.core.navigation.OnBoardRoute
 import com.kolown.porring.feature.login.LoginRoute
-import com.kolown.porring.core.navigation.Route
 
 fun NavController.navigateLogin(navOptions: NavOptions) {
-    navigate(Route.Login, navOptions = navOptions)
+    navigate(OnBoardRoute.Login, navOptions = navOptions)
 }
 
 fun NavGraphBuilder.loginNavGraph(
     popBackStack: () -> Unit,
     navigateToJoin: () -> Unit,
 ) {
-    composable<Route.Login> {
+    composable<OnBoardRoute.Login> {
         LoginRoute(
             popBackStack = popBackStack,
             navigateToJoin = navigateToJoin,

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/MainActivity.kt
@@ -9,6 +9,9 @@ import androidx.activity.viewModels
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.kolown.porring.core.designsystem.ui.theme.PorringTheme
+import com.kolown.porring.core.navigation.Route
+import com.kolown.porring.core.ui.component.LocalSnackBarBridge
+import com.kolown.porring.core.ui.component.SnackBarBridge
 import com.kolown.porring.feature.main.component.NotAvailableVersionScreen
 import com.kolown.porring.feature.main.navigation.MainNavigator
 import com.kolown.porring.feature.main.navigation.rememberMainNavigator

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/MainActivity.kt
@@ -9,9 +9,6 @@ import androidx.activity.viewModels
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.kolown.porring.core.designsystem.ui.theme.PorringTheme
-import com.kolown.porring.core.navigation.Route
-import com.kolown.porring.core.ui.component.LocalSnackBarBridge
-import com.kolown.porring.core.ui.component.SnackBarBridge
 import com.kolown.porring.feature.main.component.NotAvailableVersionScreen
 import com.kolown.porring.feature.main.navigation.MainNavigator
 import com.kolown.porring.feature.main.navigation.rememberMainNavigator
@@ -26,11 +23,10 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             val navigator: MainNavigator = rememberMainNavigator()
-            val currentRoute = navigator.currentDestination?.route?.substringAfterLast(".") ?: ""
             val versionNameState by mainViewModel.versionNameFlow.collectAsState("")
             val vName = this.packageManager.getPackageInfo(this.packageName, 0).versionName
 
-            PorringTheme(currentRoute = currentRoute) {
+            PorringTheme {
                 if (versionNameState.isNotBlank() && vName != versionNameState) {
                     NotAvailableVersionScreen(onExitAppButtonClicked = {
                         finishAndRemoveTask()

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/MainScreen.kt
@@ -75,7 +75,7 @@ internal fun MainRoute(
         )
 
         when {
-            isGranted && isLoggedIn -> navigator.navigateMainMenu(MainMenu.CAMERA)
+            isGranted && isLoggedIn -> navigator.navigateToCamera()
             isGranted -> snackBarBridge.postSnackBarEvent(SnackBarEvent.LoginRequired())
             shouldShowRationale -> showRationale = true
             else -> showSetting = true
@@ -196,12 +196,7 @@ private fun MainScreen(
                 visible = navigator.isShowBottomBar(),
                 menus = MainMenu.entries.toPersistentList(),
                 currentMenu = navigator.currentMenu,
-                onMenuSelected = { menu ->
-                    when {
-                        isTheirScreen -> navigator.navigateMainMenu(menu)
-                        menu != currentMenu -> navigator.navigateMainMenu(menu)
-                    }
-                },
+                onMenuSelected = onMenuSelected,
                 onCameraSelected = onCameraSelected,
             )
         }

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/MainScreen.kt
@@ -34,11 +34,9 @@ import androidx.compose.ui.unit.dp
 import androidx.core.app.ActivityCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.navigation.NavDestination.Companion.hasRoute
 import com.kolown.porring.core.designsystem.ui.theme.PrimaryDark
 import com.kolown.porring.core.designsystem.ui.theme.SnackBarContainer
 import com.kolown.porring.core.model.SnackBarEvent
-import com.kolown.porring.core.navigation.MainMenuRoute
 import com.kolown.porring.core.ui.compositionlocal.LocalPaddingValues
 import com.kolown.porring.core.ui.compositionlocal.LocalSnackBarBridge
 import com.kolown.porring.core.ui.compositionlocal.showSnackBarWithData
@@ -165,12 +163,19 @@ private fun MainScreen(
     onMenuSelected: (MainMenu) -> Unit = {},
     onCameraSelected: () -> Unit = {},
 ) {
-    val isTheirScreen = navigator.currentDestination?.hasRoute(MainMenuRoute.Their::class) == true
-    val currentMenu = navigator.currentMenu
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         snackbarHost = { CustomSnackBar(snackBarHostState) },
+        bottomBar = {
+            MainBottomBar(
+                visible = navigator.isShowBottomBar(),
+                menus = MainMenu.entries.toPersistentList(),
+                currentMenu = navigator.currentMenu,
+                onMenuSelected = onMenuSelected,
+                onCameraSelected = onCameraSelected,
+            )
+        }
     ) { paddingValues ->
         val bottomBarHeight = 92.dp
         val newPaddingValues = PaddingValues(
@@ -191,14 +196,6 @@ private fun MainScreen(
                     navigator = navigator,
                 )
             }
-
-            MainBottomBar(
-                visible = navigator.isShowBottomBar(),
-                menus = MainMenu.entries.toPersistentList(),
-                currentMenu = navigator.currentMenu,
-                onMenuSelected = onMenuSelected,
-                onCameraSelected = onCameraSelected,
-            )
         }
     }
 }

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainBottomBar.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainBottomBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -63,62 +64,67 @@ internal fun MainBottomBar(
     onMenuSelected: (MainMenu) -> Unit = {},
     onCameraSelected: () -> Unit = {},
 ) {
-    val density = LocalDensity.current
-    val insets = WindowInsets.systemBars
-    val navBarHeight = with(density) { insets.getBottom(this).toDp() }
-
-    AnimatedVisibility(
-        modifier = Modifier
-            .navigationBarsPadding(),
-        visible = visible,
-        enter = slideInVertically(
-            animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing),
-            initialOffsetY = { it }
-        ) + fadeIn(),
-        exit = slideOutVertically(
-            animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing),
-            targetOffsetY = { it }
-        ) + fadeOut()
+    Column(
+        verticalArrangement = Arrangement.Bottom
     ) {
-        Column {
-            Box {
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.TopCenter)
-                ) {
-                    GradientFloatingActionButton(
-                        onClick = onCameraSelected
-                    )
-
-                    Spacer(modifier = Modifier.height(30.dp))
-                }
-
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp)
-                        .align(Alignment.BottomCenter)
-                        .shadow(
-                            color = Color(0xFF598AFF).copy(alpha = 0.1f),
-                            blur = 8.dp,
-                            offsetY = (-5).dp,
-                            shape = menuBarShape(isShadow = true),
+        AnimatedVisibility(
+            visible = visible,
+            enter = slideInVertically(
+                animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing),
+                initialOffsetY = { it }
+            ) + fadeIn(),
+            exit = slideOutVertically(
+                animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing),
+                targetOffsetY = { it }
+            ) + fadeOut()
+        ) {
+            Column {
+                Box {
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.TopCenter)
+                    ) {
+                        GradientFloatingActionButton(
+                            onClick = onCameraSelected
                         )
-                        .background(
-                            color = PorringTheme.colors.surface,
-                            shape = menuBarShape()
-                        ),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    BottomBarItem(menus[0], currentMenu == menus[0], onMenuSelected)
-                    BottomBarItem(menus[1], currentMenu == menus[1], onMenuSelected)
-                    Spacer(modifier = Modifier.weight(1f))
-                    BottomBarItem(menus[2], currentMenu == menus[2], onMenuSelected)
-                    BottomBarItem(menus[3], currentMenu == menus[3], onMenuSelected)
+
+                        Spacer(modifier = Modifier.height(30.dp))
+                    }
+
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp)
+                            .align(Alignment.BottomCenter)
+                            .shadow(
+                                color = Color(0xFF598AFF).copy(alpha = 0.1f),
+                                blur = 8.dp,
+                                offsetY = (-5).dp,
+                                shape = menuBarShape(isShadow = true),
+                            )
+                            .background(
+                                color = PorringTheme.colors.surface,
+                                shape = menuBarShape()
+                            ),
+                        horizontalArrangement = Arrangement.SpaceEvenly,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        BottomBarItem(menus[0], currentMenu == menus[0], onMenuSelected)
+                        BottomBarItem(menus[1], currentMenu == menus[1], onMenuSelected)
+                        Spacer(modifier = Modifier.weight(1f))
+                        BottomBarItem(menus[2], currentMenu == menus[2], onMenuSelected)
+                        BottomBarItem(menus[3], currentMenu == menus[3], onMenuSelected)
+                    }
                 }
             }
         }
+
+        Spacer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(WindowInsets.systemBars.asPaddingValues().calculateBottomPadding())
+                .background(PorringTheme.colors.surface)
+        )
     }
 }
 

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainBottomBar.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainBottomBar.kt
@@ -22,13 +22,12 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.GenericShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -69,6 +68,7 @@ internal fun MainBottomBar(
     val navBarHeight = with(density) { insets.getBottom(this).toDp() }
 
     AnimatedVisibility(
+        modifier = Modifier.navigationBarsPadding(),
         visible = visible,
         enter = slideInVertically(
             animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing),
@@ -92,37 +92,31 @@ internal fun MainBottomBar(
                     Spacer(modifier = Modifier.height(30.dp))
                 }
 
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(56.dp)
-                    .align(Alignment.BottomCenter)
-                    .shadow(
-                        color = Color(0xFF598AFF).copy(alpha = 0.1f),
-                        blur = 8.dp,
-                        offsetY = (-5).dp,
-                        shape = menuBarShape(isShadow = true),
-                    )
-                    .background(
-                        color = PorringTheme.colors.surface,
-                        shape = menuBarShape()
-                    ),
-                horizontalArrangement = Arrangement.SpaceEvenly,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                BottomBarItem(menus[0], currentMenu == menus[0], onMenuSelected)
-                BottomBarItem(menus[1], currentMenu == menus[1], onMenuSelected)
-                Spacer(modifier = Modifier.weight(1f))
-                BottomBarItem(menus[2], currentMenu == menus[2], onMenuSelected)
-                BottomBarItem(menus[3], currentMenu == menus[3], onMenuSelected)
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(56.dp)
+                        .align(Alignment.BottomCenter)
+                        .shadow(
+                            color = Color(0xFF598AFF).copy(alpha = 0.1f),
+                            blur = 8.dp,
+                            offsetY = (-5).dp,
+                            shape = menuBarShape(isShadow = true),
+                        )
+                        .background(
+                            color = PorringTheme.colors.surface,
+                            shape = menuBarShape()
+                        ),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    BottomBarItem(menus[0], currentMenu == menus[0], onMenuSelected)
+                    BottomBarItem(menus[1], currentMenu == menus[1], onMenuSelected)
+                    Spacer(modifier = Modifier.weight(1f))
+                    BottomBarItem(menus[2], currentMenu == menus[2], onMenuSelected)
+                    BottomBarItem(menus[3], currentMenu == menus[3], onMenuSelected)
+                }
             }
-
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(navBarHeight)
-                    .background(PorringTheme.colors.surface)
-            )
         }
     }
 }

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainBottomBar.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainBottomBar.kt
@@ -51,6 +51,7 @@ import com.kolown.porring.core.designsystem.ui.theme.PorringTheme
 import com.kolown.porring.core.designsystem.ui.theme.Primary
 import com.kolown.porring.core.designsystem.ui.theme.PrimaryDark
 import com.kolown.porring.core.ui.ext.shadow
+import com.kolown.porring.feature.main.R
 import com.kolown.porring.feature.main.navigation.MainMenu
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
@@ -85,37 +86,35 @@ internal fun MainBottomBar(
                         .align(Alignment.TopCenter)
                 ) {
                     GradientFloatingActionButton(
-                        item = menus[2],
                         onClick = onCameraSelected
                     )
 
                     Spacer(modifier = Modifier.height(30.dp))
                 }
 
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(56.dp)
-                        .align(Alignment.BottomCenter)
-                        .shadow(
-                            color = Color(0xFF598AFF).copy(alpha = 0.1f),
-                            blur = 8.dp,
-                            offsetY = (-5).dp,
-                            shape = menuBarShape(isShadow = true),
-                        )
-                        .background(
-                            color = PorringTheme.colors.surface,
-                            shape = menuBarShape()
-                        ),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    BottomBarItem(menus[0], currentMenu == menus[0], onMenuSelected)
-                    BottomBarItem(menus[1], currentMenu == menus[1], onMenuSelected)
-                    Spacer(modifier = Modifier.weight(1f))
-                    BottomBarItem(menus[3], currentMenu == menus[3], onMenuSelected)
-                    BottomBarItem(menus[4], currentMenu == menus[4], onMenuSelected)
-                }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+                    .align(Alignment.BottomCenter)
+                    .shadow(
+                        color = Color(0xFF598AFF).copy(alpha = 0.1f),
+                        blur = 8.dp,
+                        offsetY = (-5).dp,
+                        shape = menuBarShape(isShadow = true),
+                    )
+                    .background(
+                        color = PorringTheme.colors.surface,
+                        shape = menuBarShape()
+                    ),
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BottomBarItem(menus[0], currentMenu == menus[0], onMenuSelected)
+                BottomBarItem(menus[1], currentMenu == menus[1], onMenuSelected)
+                Spacer(modifier = Modifier.weight(1f))
+                BottomBarItem(menus[2], currentMenu == menus[2], onMenuSelected)
+                BottomBarItem(menus[3], currentMenu == menus[3], onMenuSelected)
             }
 
             Box(
@@ -157,7 +156,6 @@ private fun RowScope.BottomBarItem(
 
 @Composable
 private fun GradientFloatingActionButton(
-    item: MainMenu,
     onClick: () -> Unit = {},
 ) {
     Box(
@@ -171,8 +169,8 @@ private fun GradientFloatingActionButton(
         contentAlignment = Alignment.Center
     ) {
         Icon(
-            imageVector = Icons.Default.Add,//TODO 아이콘 추가 바람
-            contentDescription = item.contentDescription,
+            imageVector = ImageVector.vectorResource(R.drawable.ic_add_circle_48dp),
+            contentDescription = "Camera",
             tint = Color.White,
             modifier = Modifier.fillMaxSize()
         )
@@ -235,7 +233,6 @@ private fun Preview() {
 @Composable
 private fun FloatingPreview() {
     GradientFloatingActionButton(
-        item = MainMenu.CAMERA,
         onClick = {}
     )
 }

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainBottomBar.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainBottomBar.kt
@@ -68,7 +68,8 @@ internal fun MainBottomBar(
     val navBarHeight = with(density) { insets.getBottom(this).toDp() }
 
     AnimatedVisibility(
-        modifier = Modifier.navigationBarsPadding(),
+        modifier = Modifier
+            .navigationBarsPadding(),
         visible = visible,
         enter = slideInVertically(
             animationSpec = tween(durationMillis = 300, easing = FastOutSlowInEasing),

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainNavHost.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/component/MainNavHost.kt
@@ -8,6 +8,7 @@ import androidx.navigation.compose.NavHost
 import com.kolown.porring.core.designsystem.ui.theme.PorringTheme
 import com.kolown.porring.core.model.UploadModel
 import com.kolown.porring.core.navigation.MainMenuRoute
+import com.kolown.porring.core.navigation.Route
 import com.kolown.porring.feature.camera.navigation.cameraNavGraph
 import com.kolown.porring.feature.detail.navigation.detailNavGraph
 import com.kolown.porring.feature.detail_my.navigation.detailMyNavGraph
@@ -36,13 +37,22 @@ internal fun MainNavHost(
         startDestination = navigator.startDestination,
     ) {
         homeNavGraph(
-            navigateToTheir = navigator::navigateToTheir,
+            navigateToTheir = navigator::navigateToHomeGallery,
             navigateToDetail = {
                 navigator.navigateToDetail(
-                    MainMenuRoute.Detail.Type.DEFAULT,
+                    Route.Detail.Type.DEFAULT,
                     0
                 )
             },
+            navigateToGalleryDetail = { authorId, postId ->
+                navigator.navigateToDetail(
+                    type = Route.Detail.Type.DEFAULT,
+                    order = 0,
+                    authorId = authorId,
+                    postId = postId
+                )
+            },
+            popBackStack = navigator::popBackStack
         )
 
         searchNavGraph(
@@ -58,7 +68,16 @@ internal fun MainNavHost(
 
         followerNavGraph(
             navigateToLogin = navigator::navigateToLogin,
-            navigateToTheir = navigator::navigateToTheir
+            navigateToTheir = navigator::navigateToFollowerGallery,
+            popBackStack = navigator::popBackStack,
+            navigateToDetail = { authorId, postId ->
+                navigator.navigateToDetail(
+                    type = Route.Detail.Type.FOLLOW,
+                    order = 0,
+                    authorId = authorId,
+                    postId = postId
+                )
+            },
         )
 
         myNavGraph(
@@ -67,12 +86,12 @@ internal fun MainNavHost(
             navigateToDetail = navigator::navigateToDetailMy,
         )
 
-        detailNavGraph(
-            navigateToTheir = navigator::navigateToTheir,
+        detailMyNavGraph(
             popBackStack = navigator::popBackStack
         )
 
-        detailMyNavGraph(
+        detailNavGraph(
+            navigateToTheir = navigator::navigateToTheir,
             popBackStack = navigator::popBackStack
         )
 
@@ -97,7 +116,7 @@ internal fun MainNavHost(
             popBackStack = navigator::popBackStack,
             navigateToDetail = { authorId, postId ->
                 navigator.navigateToDetail(
-                    type = MainMenuRoute.Detail.Type.FOLLOW,
+                    type = Route.Detail.Type.FOLLOW,
                     order = 0,
                     authorId = authorId,
                     postId = postId

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/navigation/MainMenu.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/navigation/MainMenu.kt
@@ -22,11 +22,6 @@ internal enum class MainMenu(
         contentDescription = "Search",
         route = MainMenuRoute.Search,
     ),
-    CAMERA(
-        iconResId = R.drawable.ic_add_circle_48dp,
-        contentDescription = "Camera",
-        route = MainMenuRoute.Camera,
-    ),
     FOLLOWER(
         iconResId = R.drawable.ic_follow,
         contentDescription = "Follow",
@@ -51,10 +46,7 @@ internal enum class MainMenu(
         @Composable
         fun contains(predicate: @Composable (Route) -> Boolean): Boolean {
             return entries
-                .mapNotNull {
-                    if (it.route == MainMenuRoute.Camera) null else it.route
-                }
-                .any { predicate(it) }
+                .any { predicate(it.route) }
         }
     }
 }

--- a/feature/main/src/main/java/com/kolown/porring/feature/main/navigation/MainNavigator.kt
+++ b/feature/main/src/main/java/com/kolown/porring/feature/main/navigation/MainNavigator.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.navigation.NavDestination
-import androidx.navigation.NavDestination.Companion.hasRoute
+import androidx.navigation.NavDestination.Companion.hierarchy
 import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -14,11 +14,14 @@ import androidx.navigation.navOptions
 import com.kolown.porring.core.model.UploadModel
 import com.kolown.porring.core.navigation.MainMenuRoute
 import com.kolown.porring.core.navigation.Route
+import com.kolown.porring.core.navigation.toRouteClassOrNull
 import com.kolown.porring.feature.camera.navigation.navigateCamera
 import com.kolown.porring.feature.detail.navigation.navigateToDetail
 import com.kolown.porring.feature.detail_my.navigation.navigateToDetailMy
 import com.kolown.porring.feature.follower.navigation.navigateFollower
+import com.kolown.porring.feature.follower.navigation.navigateFollowerGallery
 import com.kolown.porring.feature.home.navigation.navigateHome
+import com.kolown.porring.feature.home.navigation.navigateHomeGallery
 import com.kolown.porring.feature.imageedit.navigation.navigateImageEdit
 import com.kolown.porring.feature.join.navigation.navigateToJoin
 import com.kolown.porring.feature.login.navigation.navigateLogin
@@ -37,30 +40,16 @@ internal class MainNavigator(
     val navController: NavHostController,
 ) {
     val startDestination = MainMenu.HOME.route
-    private val currentTab = MutableStateFlow<MainMenu?>(MainMenu.HOME)
-
-    init {
-        navController.addOnDestinationChangedListener { _, destination, _ ->
-            val routeName = destination.route?.substringAfterLast(".") ?: ""
-
-            if (routeName.startsWith("Their")) return@addOnDestinationChangedListener
-
-            val menu = MainMenu.findByRouteName(routeName)
-
-            currentTab.update { menu }
-        }
-    }
-
     internal val currentDestination: NavDestination?
         @Composable get() = navController.currentBackStackEntryAsState().value?.destination
-    val currentMenu: MainMenu?
-        @Composable get() {
-            val last by currentTab.collectAsState()
 
-            return when {
-                currentDestination?.hasRoute(MainMenuRoute.Their::class) == true -> last
-                else -> MainMenu.find { m -> currentDestination?.hasRoute(m::class) == true }
-            }
+    val currentMenu: MainMenu?
+        @Composable get() = MainMenu.find { m ->
+            currentDestination
+                ?.hierarchy
+                ?.any { navDestination ->
+                    navDestination.route?.contains(m::class.qualifiedName.orEmpty()) == true
+                } == true
         }
     private val singleTopOptions = navOptions {
         launchSingleTop = true
@@ -78,15 +67,21 @@ internal class MainNavigator(
         when (menu) {
             MainMenu.HOME -> navController.navigateHome(navOptions)
             MainMenu.SEARCH -> navController.navigateSearch(navOptions)
-            MainMenu.CAMERA -> navController.navigateCamera(navOptions)
             MainMenu.FOLLOWER -> navController.navigateFollower(navOptions)
             MainMenu.MY -> navController.navigateMy(navOptions)
         }
     }
 
-    fun navigateToTheir(authorId: String) {
+    fun navigateToHomeGallery(authorId: String) =
+        navController.navigateHomeGallery(authorId = authorId, navOptions = singleTopOptions)
+
+    fun navigateToFollowerGallery(authorId: String) =
+        navController.navigateFollowerGallery(authorId = authorId, navOptions = singleTopOptions)
+
+    fun navigateToCamera() = navController.navigateCamera(navOptions = singleTopOptions)
+
+    fun navigateToTheir(authorId: String) =
         navController.navigateTheir(authorId = authorId, navOptions = singleTopOptions)
-    }
 
     fun navigateToImageEdit(imgUri: String) =
         navController.navigateImageEdit(imgUri = imgUri, navOptions = singleTopOptions)
@@ -95,7 +90,7 @@ internal class MainNavigator(
         navController.navigateUpload(imgUri, imageRatio, uploadModel)
 
     fun navigateToDetail(
-        type: MainMenuRoute.Detail.Type,
+        type: Route.Detail.Type,
         order: Int,
         authorId: String = "",
         postId: String? = null
@@ -118,7 +113,7 @@ internal class MainNavigator(
     fun navigateToJoin() = navController.navigateToJoin(navOptions = singleTopOptions)
 
     fun navigateToDetailSearch(tagId: String, postId: String) = navController.navigateToDetail(
-        MainMenuRoute.Detail.Type.SEARCH,
+        Route.Detail.Type.SEARCH,
         0,
         postId = postId,
         authorId = tagId,
@@ -141,10 +136,12 @@ internal class MainNavigator(
     fun popBackStack(destination: Route) = navController.popBackStack(destination, false)
 
     @Composable
-    fun isShowBottomBar() = MainMenu.contains {
-        currentDestination?.hasRoute(it::class) == true ||
-                currentDestination?.hasRoute(MainMenuRoute.Their::class) ?: false
-    }
+    fun isShowBottomBar() = navController.currentBackStackEntryAsState()
+        .value
+        ?.destination
+        ?.hierarchy
+        ?.mapNotNull { it.route?.toRouteClassOrNull() }
+        ?.firstOrNull { MainMenuRoute::class.java.isAssignableFrom(it.java) } != null
 }
 
 @Composable

--- a/feature/setting/src/main/java/com/kolown/porring/feature/setting/SettingScreen.kt
+++ b/feature/setting/src/main/java/com/kolown/porring/feature/setting/SettingScreen.kt
@@ -176,7 +176,7 @@ private fun TextMenu(
 @Preview
 @Composable
 private fun Prev() {
-    PorringTheme("") {
+    PorringTheme {
         SettingScreen()
     }
 }

--- a/feature/setting/src/main/java/com/kolown/porring/feature/setting/delete_account/DeletedAccountScreen.kt
+++ b/feature/setting/src/main/java/com/kolown/porring/feature/setting/delete_account/DeletedAccountScreen.kt
@@ -116,7 +116,7 @@ private fun DeletedAccountScreen(
 @Preview(showBackground = true)
 @Composable
 private fun Preview() {
-    PorringTheme("") {
+    PorringTheme {
         DeletedAccountScreen()
     }
 }

--- a/feature/setting/src/main/java/com/kolown/porring/feature/setting/user_info/UserInfoScreen.kt
+++ b/feature/setting/src/main/java/com/kolown/porring/feature/setting/user_info/UserInfoScreen.kt
@@ -432,7 +432,7 @@ private fun ZonedDateTime.formatText(): String {
 @Preview
 @Composable
 private fun Preview() {
-    PorringTheme("") {
+    PorringTheme {
         UserInfoScreen()
     }
 }
@@ -440,7 +440,7 @@ private fun Preview() {
 @Preview
 @Composable
 private fun Preview2() {
-    PorringTheme("") {
+    PorringTheme {
         ChangeDialog(
             title = "이메일 변경",
             description = "중요 알림과 계정 정보를 수신할" +

--- a/feature/their/src/main/java/com/kolown/porring/feature/their/TheirScreen.kt
+++ b/feature/their/src/main/java/com/kolown/porring/feature/their/TheirScreen.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-internal fun TheirRoute(
+fun TheirRoute(
     padding: PaddingValues = LocalPaddingValues.current,
     viewModel: TheirViewModel = hiltViewModel(),
     popBackStack: () -> Unit = {},

--- a/feature/their/src/main/java/com/kolown/porring/feature/their/navigation/TheirNavigation.kt
+++ b/feature/their/src/main/java/com/kolown/porring/feature/their/navigation/TheirNavigation.kt
@@ -5,18 +5,18 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.kolown.porring.core.navigation.MainMenuRoute
+import com.kolown.porring.core.navigation.Route
 import com.kolown.porring.feature.their.TheirRoute
 
 fun NavController.navigateTheir(authorId: String, navOptions: NavOptions? = null) {
-    navigate(MainMenuRoute.Their(authorId), navOptions)
+    navigate(Route.Their(authorId), navOptions)
 }
 
 fun NavGraphBuilder.theirNavGraph(
     popBackStack: () -> Unit,
     navigateToDetail: (String, String) -> Unit,
 ) {
-    composable<MainMenuRoute.Their> {
+    composable<Route.Their> { navBackStackEntry ->
         TheirRoute(
             viewModel = hiltViewModel(),
             navigateToDetail = navigateToDetail,

--- a/feature/upload/src/main/java/com/kolown/porring/feature/upload/UploadViewModel.kt
+++ b/feature/upload/src/main/java/com/kolown/porring/feature/upload/UploadViewModel.kt
@@ -10,7 +10,7 @@ import com.kolown.porring.core.common.retry
 import com.kolown.porring.core.data.repository.ImageRepository
 import com.kolown.porring.core.data.repository.PostRepository
 import com.kolown.porring.core.model.UploadModel
-import com.kolown.porring.core.navigation.Route
+import com.kolown.porring.core.navigation.CameraRoute
 import com.kolown.porring.feature.upload.navigation.UploadType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -128,6 +128,6 @@ class UploadViewModel @Inject constructor(
     }
 
     private fun extractUploadModel(): UploadModel {
-        return savedStateHandle.toRoute<Route.Upload>(mapOf(typeOf<UploadModel>() to UploadType)).uploadModel
+        return savedStateHandle.toRoute< CameraRoute.Upload>(mapOf(typeOf<UploadModel>() to UploadType)).uploadModel
     }
 }

--- a/feature/upload/src/main/java/com/kolown/porring/feature/upload/navigation/UploadNavigation.kt
+++ b/feature/upload/src/main/java/com/kolown/porring/feature/upload/navigation/UploadNavigation.kt
@@ -10,7 +10,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.kolown.porring.core.model.UploadModel
-import com.kolown.porring.core.navigation.Route
+import com.kolown.porring.core.navigation.CameraRoute
 import com.kolown.porring.feature.upload.UploadRoute
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -39,17 +39,17 @@ fun NavController.navigateUpload(
     uploadModel: UploadModel,
     navOptions: NavOptions? = null
 ) {
-    navigate(Route.Upload(imgUri, imageRatio, uploadModel), navOptions)
+    navigate(CameraRoute.Upload(imgUri, imageRatio, uploadModel), navOptions)
 }
 
 fun NavGraphBuilder.uploadNavGraph(
     navigateToHome: () -> Unit,
 ) {
-    composable<Route.Upload>(
+    composable<CameraRoute.Upload>(
         typeMap = mapOf(typeOf<UploadModel>() to UploadType)
     ) { navBackStackEntry ->
-        val imgUri = navBackStackEntry.toRoute<Route.Upload>().imgUri
-        val imageRatio = navBackStackEntry.toRoute<Route.Upload>().imageRatio
+        val imgUri = navBackStackEntry.toRoute<CameraRoute.Upload>().imgUri
+        val imageRatio = navBackStackEntry.toRoute<CameraRoute.Upload>().imageRatio
 
         UploadRoute(
             imgUri = imgUri,


### PR DESCRIPTION
## #️⃣연관 이슈
 #116 

## 📝작업 내용
내비게이션 route 정리
메인 메뉴별 독자적 백스택 관리
메인 메뉴별 바텀 내비 유지
카메라, 디테일 화면 다크모드 고정

### 작업 상세 (선택)

#### Route
````kotlin
sealed interface MainMenuRoute : Route {

    @Serializable
    data object Home : MainMenuRoute

    @Serializable
    data object Search : MainMenuRoute

    @Serializable
    data object Follower : MainMenuRoute

    @Serializable
    data object My : MainMenuRoute

}
````
메인 메뉴에 카메라 제거, 카메라는 독자적 영역이라고 생각 들어서 제거

```kotlin
sealed interface HomeRoute : MainMenuRoute {
    @Serializable
    data object Home : HomeRoute

    @Serializable
    data class HomeGallery(val authorId: String) : HomeRoute
}
```
메인 메뉴에서 갤러리로 이동등은, 해당 백스택 별도 관리를 위해 분리
바텀 내비 유지를 위해 MainMenuRoute를 상속

```kotlin
    @Composable
    fun isShowBottomBar() = navController.currentBackStackEntryAsState()
        .value
        ?.destination
        ?.hierarchy
        ?.mapNotNull { it.route?.toRouteClassOrNull() }
        ?.firstOrNull { MainMenuRoute::class.java.isAssignableFrom(it.java) } != null

fun String.toRouteClassOrNull(): KClass<out Route>? =
    when(this) {
        Route.Setting::class.qualifiedName -> Route.Setting::class
....
```
클래스 참조로 경로를 분석, 해당 경로가 MainMenuRoute기반인지 구분하고 Boolean을 배출하는 식으로 바텀바 관리
currentMenu또한 비슷한 형식으로 구현

#### 다크 모드

```kotlin
@Composable
fun DarkModeScreen(
    content: @Composable () -> Unit
) {
    val previous = remember { DarkThemeController.isDark }

    DisposableEffect(Unit) {
        DarkThemeController.setDark(true)
        onDispose { DarkThemeController.setDark(previous) }
    }

    content()
}
```
다크 모드 고정 스코프를 구현해 다크 모드로만 사용되는 부분은 해당 스코프로 감싸서 사용
화면 파괴시 기존 모드로 돌아가게 설정

```kotlin
    DarkModeScreen {
        CameraScreen(
            navigateToImageEdit = navigateToImageEdit,
            popBackStack = popBackStack,
        )
    }
```
